### PR TITLE
Phase 1: core data model v0.1

### DIFF
--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -1,0 +1,19 @@
+name: Schema validation
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r requirements-dev.txt
+      - run: python scripts/validate_schemas.py

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -1,0 +1,54 @@
+# Core Data Model — Phase 1 v0.1
+
+## Purpose
+
+Phase 1 将 Phase 0 的概念转成机器可读实体。所有 schema 使用 JSON Schema Draft 2020-12，当前 `schema_version` 为 `0.1.0`。
+
+## Entity flow
+
+Event → Evidence → Edge → Scenario → Exposure → Alert
+
+Capability 与上述链条并行，供 Exposure 与 Preparedness Engine 判断 Readiness Gap、Base Autonomy、转换能力与行动可行性。
+
+## Entities
+
+### Event
+描述发生了什么。包含 P0/P1/P2、观测域、A/B/C/D 映射和事件状态，但不直接声明因果。
+
+### Evidence
+描述“凭什么这么判断”。每条 evidence 强制区分：
+- fact
+- forecast
+- correlation
+- causality
+- opinion
+
+并记录来源类型、是否一手来源、独立性、交叉验证数量和置信度。
+
+### Edge
+描述节点之间的传导关系。状态严格使用 H0/H1/H2/H3/Hx，并支持 common-cause、反证、时滞、持续性和 falsification condition。
+
+H2/H3 在 schema 层要求至少两个 evidence reference；是否真正独立、是否足以构成因果，仍由 Evidence/Audit 层判断。
+
+### Scenario
+描述“如果这些边继续发展，会发生什么”。必须记录 Probability、Impact、Velocity、Lead Time、Reversibility，以及触发条件和证伪条件。
+
+### Exposure
+把 Event/Scenario 映射到一个不透明 subject_ref。公开数据不得用真实姓名、地址或可定位资产信息。
+
+### Capability
+描述现实准备能力与依赖：状态、容量验证级别、自治时间、单点故障、Dual-Use Value、Conversion latency。
+
+### Alert
+是对用户的输出，而不是新闻本身。P-Level、Global Stage、Personal R-Level、Governance G-Level 分字段保存，禁止混成一个“风险等级”。
+
+## Public/private rule
+
+公开仓库可以保存 schema、模型和 synthetic examples；真实 Personal Exposure 与 Capability operational data 必须进入独立私有数据层。
+
+## Non-goals of Phase 1
+
+- 不在本阶段定义 Coupling Density 精确公式；
+- 不在本阶段冻结 R-Level 触发阈值；
+- 不在本阶段存放真实个人资产清单；
+- 不把 correlation 自动升级成 causality。

--- a/examples/synthetic/alert.json
+++ b/examples/synthetic/alert.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "0.1.0",
+  "alert_id": "alt-synthetic-001",
+  "emitted_at": "2026-08-31T00:45:00Z",
+  "intelligence_priority": "P1",
+  "global_stage": "Stage-II",
+  "personal_r_level": "R1",
+  "governance_integrity": "G0",
+  "change_reason": "coupling_change",
+  "basis": {
+    "event_ids": [
+      "evt-synthetic-001"
+    ],
+    "edge_ids": [
+      "edge-synthetic-001"
+    ],
+    "scenario_ids": [
+      "scn-synthetic-001"
+    ],
+    "evidence_ids": [
+      "evd-synthetic-001"
+    ]
+  },
+  "summary": "Synthetic alert generated because a test coupling changed.",
+  "actions": [
+    "Reassess the synthetic scenario."
+  ],
+  "do_not_do": [
+    "Do not treat synthetic data as a real-world warning."
+  ],
+  "escalation_conditions": [
+    "A second independent synthetic edge validates."
+  ],
+  "deescalation_conditions": [
+    "The synthetic edge is falsified."
+  ],
+  "notify": true,
+  "sensitivity": "public"
+}

--- a/examples/synthetic/capability.json
+++ b/examples/synthetic/capability.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "0.1.0",
+  "capability_id": "cap-synthetic-communications",
+  "domain": "communications",
+  "status": "partial",
+  "capacity": {
+    "value": 2,
+    "unit": "independent_paths",
+    "verification_status": "stated"
+  },
+  "autonomy_days": null,
+  "external_dependencies": [
+    "external-power",
+    "carrier-network"
+  ],
+  "single_points_of_failure": [
+    "shared-upstream-provider"
+  ],
+  "dual_use": {
+    "peace_value": 5,
+    "resilience_value": 5
+  },
+  "conversions": [
+    {
+      "target_capability": "offline-local-network",
+      "latency_hours": 8,
+      "dependencies": [
+        "local-power",
+        "router",
+        "local-server"
+      ]
+    }
+  ],
+  "notes": "Synthetic capability only.",
+  "last_audited_at": "2026-08-31T00:40:00Z",
+  "data_sensitivity": "public"
+}

--- a/examples/synthetic/edge.json
+++ b/examples/synthetic/edge.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "0.1.0",
+  "edge_id": "edge-synthetic-001",
+  "source_node": {
+    "node_id": "climate-stress",
+    "label": "Climate stress",
+    "first_order_variable": "B",
+    "observation_domain": "climate"
+  },
+  "target_node": {
+    "node_id": "financial-conditions",
+    "label": "Financial conditions",
+    "first_order_variable": "C",
+    "observation_domain": "rates"
+  },
+  "direction": "amplifies",
+  "mechanism": "Synthetic mechanism for validation only.",
+  "state": "H1",
+  "evidence_ids": [
+    "evd-synthetic-001"
+  ],
+  "counterevidence_ids": [],
+  "common_cause": {
+    "present": false,
+    "cause_id": null,
+    "note": null
+  },
+  "latency_days": {
+    "min": 1,
+    "max": 90
+  },
+  "persistence": "unknown",
+  "metrics": [
+    {
+      "name": "synthetic_index",
+      "unit": "index",
+      "latest_value": 1.2,
+      "as_of": "2026-08-31T00:00:00Z"
+    }
+  ],
+  "falsification_condition": "Synthetic index returns to baseline without downstream response.",
+  "last_assessed_at": "2026-08-31T00:20:00Z",
+  "sensitivity": "public"
+}

--- a/examples/synthetic/event.json
+++ b/examples/synthetic/event.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "0.1.0",
+  "event_id": "evt-synthetic-001",
+  "title": "Synthetic multi-domain stress event",
+  "summary": "Synthetic test event used only to validate the public data model.",
+  "occurred_at": "2026-08-31T00:00:00Z",
+  "published_at": "2026-08-31T00:10:00Z",
+  "discovered_at": "2026-08-31T00:12:00Z",
+  "intelligence_priority": "P1",
+  "observation_domains": [
+    "climate",
+    "energy",
+    "rates",
+    "ai_capex"
+  ],
+  "first_order_variables": [
+    "B",
+    "C",
+    "D"
+  ],
+  "geography": [
+    "synthetic-region"
+  ],
+  "status": "developing",
+  "evidence_ids": [
+    "evd-synthetic-001"
+  ],
+  "tags": [
+    "synthetic",
+    "schema-test"
+  ],
+  "model_change_candidate": true,
+  "sensitivity": "public"
+}

--- a/examples/synthetic/evidence.json
+++ b/examples/synthetic/evidence.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "0.1.0",
+  "evidence_id": "evd-synthetic-001",
+  "event_id": "evt-synthetic-001",
+  "source": {
+    "name": "Synthetic Test Source",
+    "source_type": "other",
+    "uri": "https://example.invalid/source/1",
+    "published_at": "2026-08-31T00:10:00Z",
+    "primary": false
+  },
+  "claim_type": "forecast",
+  "claim": "Synthetic forecast: multiple stress indicators may strengthen concurrently.",
+  "stance": "supports",
+  "target_type": "event",
+  "target_id": "evt-synthetic-001",
+  "retrieved_at": "2026-08-31T00:12:00Z",
+  "source_locator": "synthetic-section-1",
+  "metric": {
+    "name": "synthetic_index",
+    "value": 1.2,
+    "unit": "index",
+    "as_of": "2026-08-31T00:00:00Z"
+  },
+  "quality": {
+    "provenance_score": 0.5,
+    "independence_score": 0.5,
+    "corroboration_count": 0,
+    "confidence": 0.4
+  },
+  "sensitivity": "public"
+}

--- a/examples/synthetic/exposure.json
+++ b/examples/synthetic/exposure.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "0.1.0",
+  "exposure_id": "exp-synthetic-001",
+  "subject_kind": "region",
+  "subject_ref": "synthetic-subject",
+  "hazard_ref": {
+    "type": "scenario",
+    "id": "scn-synthetic-001"
+  },
+  "dimensions": {
+    "geography": 2,
+    "assets": 1,
+    "business": 2,
+    "supply_chain": 3,
+    "finance": 2,
+    "family": 0,
+    "infrastructure": 2
+  },
+  "sensitivity_score": 2,
+  "adaptive_capacity_score": 3,
+  "resulting_r_level": "R1",
+  "rationale": "Synthetic exposure record; no real person, business or location.",
+  "updated_at": "2026-08-31T00:35:00Z",
+  "data_sensitivity": "public"
+}

--- a/examples/synthetic/scenario.json
+++ b/examples/synthetic/scenario.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "0.1.0",
+  "scenario_id": "scn-synthetic-001",
+  "title": "Synthetic climate-finance-technology resonance",
+  "summary": "Synthetic scenario for end-to-end schema validation; not a real-world forecast.",
+  "status": "watch",
+  "probability": {
+    "low": 0.2,
+    "high": 0.4,
+    "basis": "Synthetic test range only."
+  },
+  "impact": 3,
+  "velocity": "medium",
+  "lead_time": {
+    "min_days": 30,
+    "max_days": 180,
+    "confidence": 0.4
+  },
+  "reversibility": "medium",
+  "first_order_variables": [
+    "B",
+    "C",
+    "D"
+  ],
+  "event_ids": [
+    "evt-synthetic-001"
+  ],
+  "edge_ids": [
+    "edge-synthetic-001"
+  ],
+  "evidence_ids": [
+    "evd-synthetic-001"
+  ],
+  "trigger_conditions": [
+    "Two or more synthetic indicators worsen together."
+  ],
+  "disconfirming_conditions": [
+    "Synthetic indicators normalize without transmission."
+  ],
+  "updated_at": "2026-08-31T00:30:00Z",
+  "sensitivity": "public"
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+jsonschema[format]>=4.23,<5

--- a/schemas/alert.schema.json
+++ b/schemas/alert.schema.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/alert.schema.json",
+  "title": "Alert",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "alert_id",
+    "emitted_at",
+    "intelligence_priority",
+    "global_stage",
+    "personal_r_level",
+    "governance_integrity",
+    "change_reason",
+    "basis",
+    "summary",
+    "actions",
+    "do_not_do",
+    "escalation_conditions",
+    "deescalation_conditions",
+    "notify",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "alert_id": {
+      "type": "string",
+      "pattern": "^alt-[A-Za-z0-9._-]+$"
+    },
+    "emitted_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "intelligence_priority": {
+      "enum": [
+        "P0",
+        "P1",
+        "P2"
+      ]
+    },
+    "global_stage": {
+      "enum": [
+        "Stage-I",
+        "Stage-II",
+        "Stage-III",
+        "Stage-IV"
+      ]
+    },
+    "personal_r_level": {
+      "enum": [
+        "R0",
+        "R1",
+        "R2",
+        "R3",
+        "R4",
+        "R5"
+      ]
+    },
+    "governance_integrity": {
+      "enum": [
+        "G0",
+        "G1",
+        "G2",
+        "G3",
+        "G4"
+      ]
+    },
+    "change_reason": {
+      "enum": [
+        "model_state_change",
+        "coupling_change",
+        "feedback_loop_candidate",
+        "risk_level_change",
+        "hypothesis_falsified",
+        "lead_time_compression",
+        "action_change",
+        "other"
+      ]
+    },
+    "basis": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event_ids",
+        "edge_ids",
+        "scenario_ids",
+        "evidence_ids"
+      ],
+      "properties": {
+        "event_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^evt-[A-Za-z0-9._-]+$"
+          }
+        },
+        "edge_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^edge-[A-Za-z0-9._-]+$"
+          }
+        },
+        "scenario_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^scn-[A-Za-z0-9._-]+$"
+          }
+        },
+        "evidence_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^evd-[A-Za-z0-9._-]+$"
+          }
+        }
+      }
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "actions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "do_not_do": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "escalation_conditions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "deescalation_conditions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "notify": {
+      "type": "boolean"
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/capability.schema.json
+++ b/schemas/capability.schema.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/capability.schema.json",
+  "title": "Capability",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "capability_id",
+    "domain",
+    "status",
+    "external_dependencies",
+    "single_points_of_failure",
+    "dual_use",
+    "conversions",
+    "last_audited_at",
+    "data_sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "capability_id": {
+      "type": "string",
+      "pattern": "^cap-[A-Za-z0-9._-]+$"
+    },
+    "domain": {
+      "enum": [
+        "cash_flow",
+        "liquidity",
+        "asset_disposition",
+        "industrial_space",
+        "land",
+        "energy",
+        "water",
+        "food",
+        "mobility",
+        "physical_ai",
+        "communications",
+        "medical",
+        "sanitation",
+        "tools_spares",
+        "offline_knowledge",
+        "people_network"
+      ]
+    },
+    "status": {
+      "enum": [
+        "unverified",
+        "partial",
+        "confirmed",
+        "unavailable"
+      ]
+    },
+    "capacity": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "unit",
+        "verification_status"
+      ],
+      "properties": {
+        "value": {
+          "type": "number",
+          "minimum": 0
+        },
+        "unit": {
+          "type": "string",
+          "minLength": 1
+        },
+        "verification_status": {
+          "enum": [
+            "stated",
+            "measured",
+            "audited"
+          ]
+        }
+      }
+    },
+    "autonomy_days": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "external_dependencies": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      }
+    },
+    "single_points_of_failure": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      }
+    },
+    "dual_use": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "peace_value",
+        "resilience_value"
+      ],
+      "properties": {
+        "peace_value": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 5
+        },
+        "resilience_value": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 5
+        }
+      }
+    },
+    "conversions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "target_capability",
+          "latency_hours",
+          "dependencies"
+        ],
+        "properties": {
+          "target_capability": {
+            "type": "string",
+            "minLength": 1
+          },
+          "latency_hours": {
+            "type": "number",
+            "minimum": 0
+          },
+          "dependencies": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "notes": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_audited_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "data_sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/edge.schema.json
+++ b/schemas/edge.schema.json
@@ -294,6 +294,41 @@
           }
         }
       }
+    },
+    {
+      "if": {
+        "properties": {
+          "common_cause": {
+            "properties": {
+              "present": {
+                "const": true
+              }
+            },
+            "required": [
+              "present"
+            ]
+          }
+        },
+        "required": [
+          "common_cause"
+        ]
+      },
+      "then": {
+        "properties": {
+          "common_cause": {
+            "required": [
+              "present",
+              "cause_id"
+            ],
+            "properties": {
+              "cause_id": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/schemas/edge.schema.json
+++ b/schemas/edge.schema.json
@@ -1,0 +1,299 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/edge.schema.json",
+  "title": "Transmission Edge",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "edge_id",
+    "source_node",
+    "target_node",
+    "direction",
+    "mechanism",
+    "state",
+    "evidence_ids",
+    "common_cause",
+    "persistence",
+    "last_assessed_at",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "edge_id": {
+      "type": "string",
+      "pattern": "^edge-[A-Za-z0-9._-]+$"
+    },
+    "source_node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "node_id",
+        "label",
+        "first_order_variable"
+      ],
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "first_order_variable": {
+          "enum": [
+            "A",
+            "B",
+            "C",
+            "D"
+          ]
+        },
+        "observation_domain": {
+          "enum": [
+            "geopolitical_military",
+            "energy",
+            "food",
+            "water",
+            "shipping",
+            "fiscal",
+            "sovereign_debt",
+            "rates",
+            "real_estate",
+            "banking",
+            "capital_flows",
+            "climate",
+            "natural_disaster",
+            "ai_capex",
+            "technology_valuation",
+            "financing",
+            "global_trade",
+            "supply_chain",
+            "governance",
+            "social_stability",
+            "physical_ai",
+            "other"
+          ]
+        }
+      }
+    },
+    "target_node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "node_id",
+        "label",
+        "first_order_variable"
+      ],
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "first_order_variable": {
+          "enum": [
+            "A",
+            "B",
+            "C",
+            "D"
+          ]
+        },
+        "observation_domain": {
+          "enum": [
+            "geopolitical_military",
+            "energy",
+            "food",
+            "water",
+            "shipping",
+            "fiscal",
+            "sovereign_debt",
+            "rates",
+            "real_estate",
+            "banking",
+            "capital_flows",
+            "climate",
+            "natural_disaster",
+            "ai_capex",
+            "technology_valuation",
+            "financing",
+            "global_trade",
+            "supply_chain",
+            "governance",
+            "social_stability",
+            "physical_ai",
+            "other"
+          ]
+        }
+      }
+    },
+    "direction": {
+      "enum": [
+        "amplifies",
+        "dampens",
+        "mixed"
+      ]
+    },
+    "mechanism": {
+      "type": "string",
+      "minLength": 1
+    },
+    "state": {
+      "enum": [
+        "H0",
+        "H1",
+        "H2",
+        "H3",
+        "Hx"
+      ]
+    },
+    "evidence_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^evd-[A-Za-z0-9._-]+$"
+      }
+    },
+    "counterevidence_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^evd-[A-Za-z0-9._-]+$"
+      }
+    },
+    "common_cause": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "present"
+      ],
+      "properties": {
+        "present": {
+          "type": "boolean"
+        },
+        "cause_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "note": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "latency_days": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "required": [
+        "min",
+        "max"
+      ],
+      "properties": {
+        "min": {
+          "type": "number",
+          "minimum": 0
+        },
+        "max": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "persistence": {
+      "enum": [
+        "transient",
+        "persistent",
+        "structural",
+        "unknown"
+      ]
+    },
+    "metrics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "unit"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "unit": {
+            "type": "string"
+          },
+          "latest_value": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "as_of": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "falsification_condition": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_assessed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "H2",
+              "H3"
+            ]
+          }
+        },
+        "required": [
+          "state"
+        ]
+      },
+      "then": {
+        "properties": {
+          "evidence_ids": {
+            "minItems": 2
+          }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/event.schema.json
+++ b/schemas/event.schema.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/event.schema.json",
+  "title": "Event",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "event_id",
+    "title",
+    "summary",
+    "occurred_at",
+    "discovered_at",
+    "intelligence_priority",
+    "observation_domains",
+    "first_order_variables",
+    "status",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "event_id": {
+      "type": "string",
+      "pattern": "^evt-[A-Za-z0-9._-]+$"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 240
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "published_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "discovered_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "intelligence_priority": {
+      "enum": [
+        "P0",
+        "P1",
+        "P2"
+      ]
+    },
+    "observation_domains": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "geopolitical_military",
+          "energy",
+          "food",
+          "water",
+          "shipping",
+          "fiscal",
+          "sovereign_debt",
+          "rates",
+          "real_estate",
+          "banking",
+          "capital_flows",
+          "climate",
+          "natural_disaster",
+          "ai_capex",
+          "technology_valuation",
+          "financing",
+          "global_trade",
+          "supply_chain",
+          "governance",
+          "social_stability",
+          "physical_ai",
+          "other"
+        ]
+      }
+    },
+    "first_order_variables": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "A",
+          "B",
+          "C",
+          "D"
+        ]
+      }
+    },
+    "geography": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "status": {
+      "enum": [
+        "developing",
+        "confirmed",
+        "contained",
+        "reversed",
+        "closed"
+      ]
+    },
+    "evidence_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^evd-[A-Za-z0-9._-]+$"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      }
+    },
+    "model_change_candidate": {
+      "type": "boolean",
+      "default": false
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/evidence.schema.json
+++ b/schemas/evidence.schema.json
@@ -1,0 +1,187 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/evidence.schema.json",
+  "title": "Evidence",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "evidence_id",
+    "event_id",
+    "source",
+    "claim_type",
+    "claim",
+    "stance",
+    "target_type",
+    "target_id",
+    "retrieved_at",
+    "quality",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "evidence_id": {
+      "type": "string",
+      "pattern": "^evd-[A-Za-z0-9._-]+$"
+    },
+    "event_id": {
+      "type": "string",
+      "pattern": "^evt-[A-Za-z0-9._-]+$"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "source_type",
+        "primary"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_type": {
+          "enum": [
+            "government",
+            "international_organization",
+            "company_primary",
+            "market_data",
+            "academic",
+            "media",
+            "osint",
+            "field",
+            "other"
+          ]
+        },
+        "uri": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "published_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "primary": {
+          "type": "boolean"
+        }
+      }
+    },
+    "claim_type": {
+      "enum": [
+        "fact",
+        "forecast",
+        "correlation",
+        "causality",
+        "opinion"
+      ]
+    },
+    "claim": {
+      "type": "string",
+      "minLength": 1
+    },
+    "stance": {
+      "enum": [
+        "supports",
+        "refutes",
+        "context"
+      ]
+    },
+    "target_type": {
+      "enum": [
+        "event",
+        "edge",
+        "scenario"
+      ]
+    },
+    "target_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "retrieved_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_locator": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "metric": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "value",
+        "unit",
+        "as_of"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "number"
+        },
+        "unit": {
+          "type": "string"
+        },
+        "as_of": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "quality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provenance_score",
+        "independence_score",
+        "corroboration_count",
+        "confidence"
+      ],
+      "properties": {
+        "provenance_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "independence_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "corroboration_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/exposure.schema.json
+++ b/schemas/exposure.schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/exposure.schema.json",
+  "title": "Exposure",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "exposure_id",
+    "subject_kind",
+    "subject_ref",
+    "hazard_ref",
+    "dimensions",
+    "sensitivity_score",
+    "adaptive_capacity_score",
+    "resulting_r_level",
+    "rationale",
+    "updated_at",
+    "data_sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "exposure_id": {
+      "type": "string",
+      "pattern": "^exp-[A-Za-z0-9._-]+$"
+    },
+    "subject_kind": {
+      "enum": [
+        "person",
+        "family",
+        "enterprise",
+        "base",
+        "asset",
+        "region"
+      ]
+    },
+    "subject_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Opaque identifier; do not place personal names or precise locations in public data."
+    },
+    "hazard_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "id"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "event",
+            "scenario"
+          ]
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "dimensions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "geography",
+        "assets",
+        "business",
+        "supply_chain",
+        "finance",
+        "family",
+        "infrastructure"
+      ],
+      "properties": {
+        "geography": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 5
+        },
+        "assets": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 5
+        },
+        "business": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 5
+        },
+        "supply_chain": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 5
+        },
+        "finance": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 5
+        },
+        "family": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 5
+        },
+        "infrastructure": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 5
+        }
+      }
+    },
+    "sensitivity_score": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 5
+    },
+    "adaptive_capacity_score": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 5
+    },
+    "resulting_r_level": {
+      "enum": [
+        "R0",
+        "R1",
+        "R2",
+        "R3",
+        "R4",
+        "R5"
+      ]
+    },
+    "rationale": {
+      "type": "string",
+      "minLength": 1
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "data_sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/scenario.schema.json
+++ b/schemas/scenario.schema.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/scenario.schema.json",
+  "title": "Scenario",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "scenario_id",
+    "title",
+    "summary",
+    "status",
+    "probability",
+    "impact",
+    "velocity",
+    "lead_time",
+    "reversibility",
+    "first_order_variables",
+    "trigger_conditions",
+    "disconfirming_conditions",
+    "updated_at",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "scenario_id": {
+      "type": "string",
+      "pattern": "^scn-[A-Za-z0-9._-]+$"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "enum": [
+        "watch",
+        "active",
+        "escalating",
+        "deescalating",
+        "closed",
+        "falsified"
+      ]
+    },
+    "probability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "low",
+        "high",
+        "basis"
+      ],
+      "properties": {
+        "low": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "high": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "basis": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "impact": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 5
+    },
+    "velocity": {
+      "enum": [
+        "slow",
+        "medium",
+        "fast",
+        "acute"
+      ]
+    },
+    "lead_time": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "min_days",
+        "max_days",
+        "confidence"
+      ],
+      "properties": {
+        "min_days": {
+          "type": "number",
+          "minimum": 0
+        },
+        "max_days": {
+          "type": "number",
+          "minimum": 0
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    },
+    "reversibility": {
+      "enum": [
+        "high",
+        "medium",
+        "low",
+        "none"
+      ]
+    },
+    "first_order_variables": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "A",
+          "B",
+          "C",
+          "D"
+        ]
+      }
+    },
+    "event_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^evt-[A-Za-z0-9._-]+$"
+      }
+    },
+    "edge_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^edge-[A-Za-z0-9._-]+$"
+      }
+    },
+    "evidence_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^evd-[A-Za-z0-9._-]+$"
+      }
+    },
+    "trigger_conditions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "disconfirming_conditions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/scripts/validate_schemas.py
+++ b/scripts/validate_schemas.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+from jsonschema import Draft202012Validator, FormatChecker
+
+ROOT = Path(__file__).resolve().parents[1]
+PAIRS = {
+    "event": ("schemas/event.schema.json", "examples/synthetic/event.json"),
+    "evidence": ("schemas/evidence.schema.json", "examples/synthetic/evidence.json"),
+    "edge": ("schemas/edge.schema.json", "examples/synthetic/edge.json"),
+    "scenario": ("schemas/scenario.schema.json", "examples/synthetic/scenario.json"),
+    "exposure": ("schemas/exposure.schema.json", "examples/synthetic/exposure.json"),
+    "capability": ("schemas/capability.schema.json", "examples/synthetic/capability.json"),
+    "alert": ("schemas/alert.schema.json", "examples/synthetic/alert.json"),
+}
+
+def load(path):
+    with (ROOT / path).open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+def main():
+    failures = []
+    for name, (schema_path, example_path) in PAIRS.items():
+        schema = load(schema_path)
+        example = load(example_path)
+        try:
+            Draft202012Validator.check_schema(schema)
+            Draft202012Validator(schema, format_checker=FormatChecker()).validate(example)
+            print(f"PASS {name}: {example_path}")
+        except Exception as exc:
+            failures.append((name, str(exc)))
+            print(f"FAIL {name}: {exc}")
+    if failures:
+        raise SystemExit(1)
+    print(f"PASS all: {len(PAIRS)}/{len(PAIRS)} schemas and examples validated")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_schemas.py
+++ b/scripts/validate_schemas.py
@@ -18,6 +18,29 @@ def load(path):
     with (ROOT / path).open("r", encoding="utf-8") as f:
         return json.load(f)
 
+def semantic_errors(name, obj):
+    errors = []
+    if name == "scenario":
+        p = obj["probability"]
+        if p["low"] > p["high"]:
+            errors.append("probability.low must be <= probability.high")
+        lead = obj["lead_time"]
+        if lead["min_days"] > lead["max_days"]:
+            errors.append("lead_time.min_days must be <= lead_time.max_days")
+    elif name == "edge":
+        if obj["source_node"]["node_id"] == obj["target_node"]["node_id"]:
+            errors.append("source_node and target_node must differ")
+        latency = obj.get("latency_days")
+        if latency and latency["min"] > latency["max"]:
+            errors.append("latency_days.min must be <= latency_days.max")
+        common = obj["common_cause"]
+        if common["present"] and not common.get("cause_id"):
+            errors.append("common_cause.cause_id is required when present=true")
+    elif name == "alert" and obj["notify"]:
+        if not any(obj["basis"].values()):
+            errors.append("notify=true requires at least one basis reference")
+    return errors
+
 def main():
     failures = []
     for name, (schema_path, example_path) in PAIRS.items():
@@ -26,6 +49,9 @@ def main():
         try:
             Draft202012Validator.check_schema(schema)
             Draft202012Validator(schema, format_checker=FormatChecker()).validate(example)
+            semantic = semantic_errors(name, example)
+            if semantic:
+                raise ValueError("; ".join(semantic))
             print(f"PASS {name}: {example_path}")
         except Exception as exc:
             failures.append((name, str(exc)))


### PR DESCRIPTION
Closes #1

## What this adds

- 7 JSON Schema Draft 2020-12 entity models:
  - Event
  - Evidence
  - Edge
  - Scenario
  - Exposure
  - Capability
  - Alert
- Synthetic public-safe examples for every entity
- Data model documentation
- Python schema/example validator
- GitHub Actions schema validation

## Critical invariants

- Fact / Forecast / Correlation / Causality / Opinion are explicit evidence types.
- P0/P1/P2, Stage I-IV, R0-R5, G0-G4 remain separate fields.
- H2/H3 edges require at least two evidence references.
- Common-cause and counterevidence are first-class fields.
- Scenario requires Probability / Impact / Velocity / Lead Time / Reversibility.
- Public branch contains no real personal/base operational data.

## Review gate

Do not treat synthetic examples as real-world judgments. Phase 1 defines structure only; Coupling Density math and R-level thresholds remain Phase 2.
