### PR TITLE
Phase 3C-WATER: water resilience verification v0.1

### DIFF
--- a/docs/WATER-RESILIENCE-VERIFICATION.md
+++ b/docs/WATER-RESILIENCE-VERIFICATION.md
@@ -1,0 +1,72 @@
+# Water Resilience Verification v0.1
+
+## Why water is audited as a chain
+
+“有井”只能证明一个潜在水源存在，不能证明在停电、污染、泵故障或长期高负荷条件下仍有可饮用水。
+
+水韧性链：
+
+`Source → Extraction → Power → Storage → Treatment → Quality → Distribution → Maintenance/Spares → Outage Test`
+
+任何关键环节未知，都会限制验证等级。
+
+## Verification ladder
+
+### stated
+只知道水源存在或有人陈述存在。
+
+### measured
+至少有可复核的供水测量，例如：
+- 持续流量测试；或
+- 可用储水容量测量。
+
+这仍然不等于停电可用，也不等于可饮用。
+
+### field_tested
+必须通过现实 outage/degraded-mode 测试：
+- 断开正常外部依赖后仍能取水；
+- 若目标包括饮用水，水质有适当实验室/权威证据；
+- 若需要处理，处理路径已实际测试；
+- 记录测试持续时间。
+
+系统只记录 **minimum demonstrated continuity**，不因为井能持续出水就写“无限自治”。
+
+### audited
+在 field_tested 基础上，还要求：
+- evidence 完整；
+- maintenance current；
+- 独立复核完成；
+- 关键 dependency 有可用 backup；
+- 已知 SPOF 已清除或降级处理。
+
+## Potability safety gate
+
+以下信息不能单独证明饮水安全：
+- 肉眼清澈；
+- 无异味；
+- 口感正常；
+- TDS/电导率；
+- 普通家用传感器。
+
+如系统用途包含 potable/mixed，只有适当实验室或主管机构证据才通过 potability gate。具体检测项目应依据当地水源风险和适用标准确定。
+
+## Measurements to collect
+
+1. source verification
+2. flow / pump-test result
+3. usable storage
+4. extraction power path
+5. backup power
+6. treatment path
+7. water-quality evidence
+8. daily demand assumption
+9. outage/degraded-mode test duration
+10. pump/filter/spares and maintenance
+11. critical dependencies / SPOFs
+
+## Autonomy discipline
+
+- `storage_autonomy_days = usable_storage / daily_demand` only when both are measured/defensible.
+- Continuous well flow creates a **continuous_source_candidate**, not an infinite-day claim.
+- Outage testing produces a **minimum demonstrated continuity** lower bound.
+- Base Autonomy should only consume a water autonomy value that is defensible under the relevant scenario.

--- a/examples/synthetic/water-resilience-audit.json
+++ b/examples/synthetic/water-resilience-audit.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "0.1.0",
+  "water_audit_id": "wra-synthetic-001",
+  "capability_id": "cap-synthetic-water",
+  "service_scope": "potable",
+  "source": {
+    "source_type": "well",
+    "presence_confirmed": true,
+    "source_verification": "measured",
+    "notes": "Synthetic only."
+  },
+  "hydraulics": {
+    "flow_test": {
+      "method": "metered",
+      "duration_minutes": 60,
+      "sustained_flow_lpm": 8,
+      "recovery_minutes": null,
+      "notes": "Synthetic."
+    },
+    "usable_storage_liters": 1200
+  },
+  "power": {
+    "extraction_requires_power": true,
+    "primary_power": "grid",
+    "backup_power_status": "ready",
+    "outage_extraction_test": "pass"
+  },
+  "treatment": {
+    "required": true,
+    "system_status": "operational_tested"
+  },
+  "quality": {
+    "potability_status": "lab_verified",
+    "evidence_date": "2026-08-30",
+    "evidence_ref": "synthetic-lab",
+    "consumer_sensor_only": false
+  },
+  "continuity": {
+    "daily_demand_liters": 120,
+    "outage_test": "pass",
+    "field_test_duration_hours": 24
+  },
+  "dependencies": [
+    {
+      "dependency_id": "backup-power",
+      "kind": "power",
+      "critical": true,
+      "backup_status": "ready"
+    }
+  ],
+  "single_points_of_failure": [],
+  "maintenance_status": "current",
+  "independent_review_completed": false,
+  "evidence_refs": [
+    "synthetic-flow",
+    "synthetic-lab",
+    "synthetic-outage"
+  ],
+  "updated_at": "2026-08-31T00:00:00Z",
+  "data_sensitivity": "public"
+}

--- a/examples/synthetic/water-verification-assessment.json
+++ b/examples/synthetic/water-verification-assessment.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "0.1.0",
+  "assessment_id": "wva-synthetic-001",
+  "water_audit_id": "wra-synthetic-001",
+  "recommended_verification_status": "field_tested",
+  "potability_gate_passed": true,
+  "outage_gate_passed": true,
+  "storage_autonomy_days": 10,
+  "minimum_demonstrated_continuity_days": 1,
+  "continuous_source_candidate": true,
+  "blockers": [],
+  "as_of": "2026-08-31T00:00:00Z",
+  "sensitivity": "public"
+}

--- a/schemas/water-resilience-audit.schema.json
+++ b/schemas/water-resilience-audit.schema.json
@@ -1,0 +1,360 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/water-resilience-audit.schema.json",
+  "title": "Water Resilience Audit",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "water_audit_id",
+    "capability_id",
+    "service_scope",
+    "source",
+    "hydraulics",
+    "power",
+    "treatment",
+    "quality",
+    "continuity",
+    "dependencies",
+    "single_points_of_failure",
+    "maintenance_status",
+    "independent_review_completed",
+    "evidence_refs",
+    "updated_at",
+    "data_sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "water_audit_id": {
+      "type": "string",
+      "pattern": "^wra-[A-Za-z0-9._-]+$"
+    },
+    "capability_id": {
+      "type": "string",
+      "pattern": "^cap-[A-Za-z0-9._-]+$"
+    },
+    "service_scope": {
+      "enum": [
+        "non_potable",
+        "potable",
+        "mixed"
+      ]
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_type",
+        "presence_confirmed",
+        "source_verification"
+      ],
+      "properties": {
+        "source_type": {
+          "enum": [
+            "well",
+            "municipal",
+            "stored",
+            "surface",
+            "rainwater",
+            "other"
+          ]
+        },
+        "presence_confirmed": {
+          "type": "boolean"
+        },
+        "source_verification": {
+          "enum": [
+            "stated",
+            "observed",
+            "measured",
+            "documented"
+          ]
+        },
+        "notes": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "hydraulics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "flow_test",
+        "usable_storage_liters"
+      ],
+      "properties": {
+        "flow_test": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "required": [
+            "method",
+            "duration_minutes",
+            "sustained_flow_lpm"
+          ],
+          "properties": {
+            "method": {
+              "enum": [
+                "container_timed",
+                "metered",
+                "pump_test",
+                "other"
+              ]
+            },
+            "duration_minutes": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "sustained_flow_lpm": {
+              "type": "number",
+              "minimum": 0
+            },
+            "recovery_minutes": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "minimum": 0
+            },
+            "notes": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "usable_storage_liters": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        }
+      }
+    },
+    "power": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "extraction_requires_power",
+        "primary_power",
+        "backup_power_status",
+        "outage_extraction_test"
+      ],
+      "properties": {
+        "extraction_requires_power": {
+          "type": "boolean"
+        },
+        "primary_power": {
+          "enum": [
+            "grid",
+            "solar",
+            "generator",
+            "battery",
+            "manual",
+            "other",
+            "unknown"
+          ]
+        },
+        "backup_power_status": {
+          "enum": [
+            "none",
+            "unknown",
+            "partial",
+            "ready",
+            "not_required"
+          ]
+        },
+        "outage_extraction_test": {
+          "enum": [
+            "not_run",
+            "pass",
+            "fail",
+            "partial"
+          ]
+        }
+      }
+    },
+    "treatment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "required",
+        "system_status"
+      ],
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "system_status": {
+          "enum": [
+            "unknown",
+            "absent",
+            "present_unverified",
+            "operational_tested"
+          ]
+        }
+      }
+    },
+    "quality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "potability_status",
+        "evidence_date",
+        "evidence_ref",
+        "consumer_sensor_only"
+      ],
+      "properties": {
+        "potability_status": {
+          "enum": [
+            "unknown",
+            "not_potable",
+            "lab_verified",
+            "authority_verified"
+          ]
+        },
+        "evidence_date": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "evidence_ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "consumer_sensor_only": {
+          "type": "boolean"
+        }
+      }
+    },
+    "continuity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "daily_demand_liters",
+        "outage_test",
+        "field_test_duration_hours"
+      ],
+      "properties": {
+        "daily_demand_liters": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "exclusiveMinimum": 0
+        },
+        "outage_test": {
+          "enum": [
+            "not_run",
+            "pass",
+            "fail",
+            "partial"
+          ]
+        },
+        "field_test_duration_hours": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        }
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "dependency_id",
+          "kind",
+          "critical",
+          "backup_status"
+        ],
+        "properties": {
+          "dependency_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "kind": {
+            "enum": [
+              "power",
+              "pump",
+              "storage",
+              "treatment",
+              "water_quality",
+              "spares",
+              "personnel",
+              "logistics",
+              "other"
+            ]
+          },
+          "critical": {
+            "type": "boolean"
+          },
+          "backup_status": {
+            "enum": [
+              "none",
+              "partial",
+              "ready",
+              "unknown",
+              "not_required"
+            ]
+          }
+        }
+      }
+    },
+    "single_points_of_failure": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "maintenance_status": {
+      "enum": [
+        "current",
+        "due",
+        "overdue",
+        "unknown"
+      ]
+    },
+    "independent_review_completed": {
+      "type": "boolean"
+    },
+    "evidence_refs": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "data_sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/water-verification-assessment.schema.json
+++ b/schemas/water-verification-assessment.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/water-verification-assessment.schema.json",
+  "title": "Water Verification Assessment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "assessment_id",
+    "water_audit_id",
+    "recommended_verification_status",
+    "potability_gate_passed",
+    "outage_gate_passed",
+    "storage_autonomy_days",
+    "minimum_demonstrated_continuity_days",
+    "continuous_source_candidate",
+    "blockers",
+    "as_of",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "assessment_id": {
+      "type": "string",
+      "pattern": "^wva-[A-Za-z0-9._-]+$"
+    },
+    "water_audit_id": {
+      "type": "string",
+      "pattern": "^wra-[A-Za-z0-9._-]+$"
+    },
+    "recommended_verification_status": {
+      "enum": [
+        "stated",
+        "measured",
+        "field_tested",
+        "audited"
+      ]
+    },
+    "potability_gate_passed": {
+      "type": "boolean"
+    },
+    "outage_gate_passed": {
+      "type": "boolean"
+    },
+    "storage_autonomy_days": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "minimum_demonstrated_continuity_days": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "continuous_source_candidate": {
+      "type": "boolean"
+    },
+    "blockers": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "as_of": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/scripts/validate_schemas.py
+++ b/scripts/validate_schemas.py
@@ -19,6 +19,8 @@ PAIRS = {
     "r_level_assessment": ("schemas/r-level-assessment.schema.json", "examples/synthetic/r-level-assessment.json"),
     "capability_audit": ("schemas/capability-audit.schema.json", "examples/synthetic/capability-audit.json"),
     "preparedness_snapshot": ("schemas/preparedness-snapshot.schema.json", "examples/synthetic/preparedness-snapshot.json"),
+    "water_resilience_audit": ("schemas/water-resilience-audit.schema.json", "examples/synthetic/water-resilience-audit.json"),
+    "water_verification_assessment": ("schemas/water-verification-assessment.schema.json", "examples/synthetic/water-verification-assessment.json"),
 }
 
 def load(path):
@@ -61,6 +63,17 @@ def semantic_errors(name, obj):
             errors.append("coactivation_breadth inconsistent with active variable count")
         if obj["independent_validated_directed_pairs"] > obj["unique_validated_directed_pairs"]:
             errors.append("independent pair count cannot exceed raw pair count")
+    elif name == "water_resilience_audit":
+        quality = obj["quality"]
+        if quality["potability_status"] in {"lab_verified", "authority_verified"}:
+            if not quality.get("evidence_date") or not quality.get("evidence_ref"):
+                errors.append("verified potability requires evidence_date and evidence_ref")
+        if quality["consumer_sensor_only"] and quality["potability_status"] in {"lab_verified", "authority_verified"}:
+            errors.append("consumer_sensor_only cannot establish verified potability")
+        continuity = obj["continuity"]
+        if continuity["outage_test"] == "pass":
+            if not continuity.get("field_test_duration_hours") or continuity["field_test_duration_hours"] <= 0:
+                errors.append("passed outage test requires positive field_test_duration_hours")
     return errors
 
 def main():

--- a/src/psrro/__init__.py
+++ b/src/psrro/__init__.py
@@ -1,3 +1,4 @@
+from .water import assess_water_verification
 from .preparedness import preparedness_snapshot
 from .quantification import (
     buffer_floor_days,
@@ -9,6 +10,7 @@ from .quantification import (
 )
 
 __all__ = [
+    "assess_water_verification",
     "preparedness_snapshot",
     "buffer_floor_days",
     "buffer_remaining_fraction",

--- a/src/psrro/water.py
+++ b/src/psrro/water.py
@@ -1,0 +1,114 @@
+"""Water-resilience verification v0.1.
+
+This module deliberately avoids claiming indefinite water autonomy from the
+mere existence of a well. It reports measured storage autonomy and minimum
+demonstrated continuity separately.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def assess_water_verification(audit: Mapping) -> dict:
+    blockers: list[str] = []
+
+    source = audit["source"]
+    hydraulics = audit["hydraulics"]
+    power = audit["power"]
+    treatment = audit["treatment"]
+    quality = audit["quality"]
+    continuity = audit["continuity"]
+    scope = audit["service_scope"]
+
+    source_present = bool(source["presence_confirmed"])
+    measured_supply = (
+        hydraulics.get("flow_test") is not None
+        or hydraulics.get("usable_storage_liters") is not None
+    )
+
+    potability_required = scope in {"potable", "mixed"}
+    potability_gate = (
+        not potability_required
+        or quality["potability_status"] in {"lab_verified", "authority_verified"}
+    )
+
+    if quality.get("consumer_sensor_only") and potability_required:
+        blockers.append("consumer sensors do not establish potability")
+
+    extraction_power_gate = (
+        not power["extraction_requires_power"]
+        or power["outage_extraction_test"] == "pass"
+        or power["primary_power"] == "manual"
+    )
+    outage_gate = continuity["outage_test"] == "pass" and extraction_power_gate
+
+    if power["extraction_requires_power"] and power["outage_extraction_test"] != "pass":
+        blockers.append("outage extraction path not demonstrated")
+
+    if potability_required and not potability_gate:
+        blockers.append("potability not independently verified")
+
+    if potability_required and treatment["required"] and treatment["system_status"] != "operational_tested":
+        blockers.append("required treatment path not operationally tested")
+
+    storage = hydraulics.get("usable_storage_liters")
+    demand = continuity.get("daily_demand_liters")
+    storage_days = None
+    if storage is not None and demand is not None:
+        storage_days = storage / demand
+
+    field_hours = continuity.get("field_test_duration_hours")
+    demonstrated_days = None
+    if outage_gate and field_hours is not None:
+        demonstrated_days = field_hours / 24.0
+
+    flow = hydraulics.get("flow_test")
+    continuous_candidate = bool(
+        flow
+        and flow.get("sustained_flow_lpm", 0) > 0
+        and outage_gate
+        and (potability_gate or not potability_required)
+    )
+
+    if not source_present:
+        blockers.append("water source presence not confirmed")
+        status = "stated"
+    elif not measured_supply:
+        blockers.append("no measured flow or usable storage")
+        status = "stated"
+    else:
+        status = "measured"
+
+    if status == "measured" and outage_gate and (potability_gate or not potability_required):
+        if not (potability_required and treatment["required"] and treatment["system_status"] != "operational_tested"):
+            status = "field_tested"
+
+    if (
+        status == "field_tested"
+        and audit.get("independent_review_completed")
+        and audit.get("maintenance_status") == "current"
+        and audit.get("evidence_refs")
+        and not audit.get("single_points_of_failure")
+        and all(
+            dep.get("backup_status") not in {"none", "unknown"}
+            for dep in audit.get("dependencies", [])
+            if dep.get("critical")
+        )
+    ):
+        status = "audited"
+
+    return {
+        "schema_version": "0.1.0",
+        "assessment_id": f"wva-{audit['water_audit_id'][4:]}",
+        "water_audit_id": audit["water_audit_id"],
+        "recommended_verification_status": status,
+        "potability_gate_passed": potability_gate,
+        "outage_gate_passed": outage_gate,
+        "storage_autonomy_days": None if storage_days is None else round(storage_days, 6),
+        "minimum_demonstrated_continuity_days": None if demonstrated_days is None else round(demonstrated_days, 6),
+        "continuous_source_candidate": continuous_candidate,
+        "blockers": sorted(set(blockers)),
+        "as_of": audit["updated_at"],
+        "sensitivity": audit["data_sensitivity"],
+    }

--- a/tests/test_water.py
+++ b/tests/test_water.py
@@ -1,0 +1,132 @@
+import unittest
+
+from src.psrro.water import assess_water_verification
+
+
+def base_audit():
+    return {
+        "schema_version": "0.1.0",
+        "water_audit_id": "wra-synthetic",
+        "capability_id": "cap-synthetic-water",
+        "service_scope": "potable",
+        "source": {
+            "source_type": "well",
+            "presence_confirmed": True,
+            "source_verification": "stated",
+            "notes": None,
+        },
+        "hydraulics": {"flow_test": None, "usable_storage_liters": None},
+        "power": {
+            "extraction_requires_power": True,
+            "primary_power": "grid",
+            "backup_power_status": "unknown",
+            "outage_extraction_test": "not_run",
+        },
+        "treatment": {"required": True, "system_status": "unknown"},
+        "quality": {
+            "potability_status": "unknown",
+            "evidence_date": None,
+            "evidence_ref": None,
+            "consumer_sensor_only": False,
+        },
+        "continuity": {
+            "daily_demand_liters": None,
+            "outage_test": "not_run",
+            "field_test_duration_hours": None,
+        },
+        "dependencies": [],
+        "single_points_of_failure": [],
+        "maintenance_status": "unknown",
+        "independent_review_completed": False,
+        "evidence_refs": ["synthetic"],
+        "updated_at": "2026-08-31T00:00:00Z",
+        "data_sensitivity": "public",
+    }
+
+
+class WaterVerificationTests(unittest.TestCase):
+    def test_source_only_remains_stated(self):
+        result = assess_water_verification(base_audit())
+        self.assertEqual(result["recommended_verification_status"], "stated")
+        self.assertIsNone(result["storage_autonomy_days"])
+
+    def test_measured_storage_does_not_become_field_tested(self):
+        audit = base_audit()
+        audit["hydraulics"]["usable_storage_liters"] = 1000
+        audit["continuity"]["daily_demand_liters"] = 100
+        result = assess_water_verification(audit)
+        self.assertEqual(result["recommended_verification_status"], "measured")
+        self.assertEqual(result["storage_autonomy_days"], 10.0)
+
+    def test_consumer_sensor_does_not_establish_potability(self):
+        audit = base_audit()
+        audit["hydraulics"]["usable_storage_liters"] = 1000
+        audit["quality"]["consumer_sensor_only"] = True
+        result = assess_water_verification(audit)
+        self.assertFalse(result["potability_gate_passed"])
+        self.assertIn("consumer sensors do not establish potability", result["blockers"])
+
+    def test_field_test_requires_outage_and_potability_gate(self):
+        audit = base_audit()
+        audit["hydraulics"]["flow_test"] = {
+            "method": "metered",
+            "duration_minutes": 60,
+            "sustained_flow_lpm": 10,
+            "recovery_minutes": None,
+            "notes": None,
+        }
+        audit["power"]["outage_extraction_test"] = "pass"
+        audit["power"]["backup_power_status"] = "ready"
+        audit["treatment"]["system_status"] = "operational_tested"
+        audit["quality"]["potability_status"] = "lab_verified"
+        audit["quality"]["evidence_date"] = "2026-08-30"
+        audit["quality"]["evidence_ref"] = "synthetic-lab"
+        audit["continuity"]["outage_test"] = "pass"
+        audit["continuity"]["field_test_duration_hours"] = 24
+        result = assess_water_verification(audit)
+        self.assertEqual(result["recommended_verification_status"], "field_tested")
+        self.assertEqual(result["minimum_demonstrated_continuity_days"], 1.0)
+        self.assertTrue(result["continuous_source_candidate"])
+
+    def test_continuous_source_candidate_is_not_infinite_autonomy(self):
+        audit = base_audit()
+        audit["hydraulics"]["flow_test"] = {
+            "method": "pump_test",
+            "duration_minutes": 120,
+            "sustained_flow_lpm": 20,
+            "recovery_minutes": 30,
+            "notes": None,
+        }
+        audit["power"]["outage_extraction_test"] = "pass"
+        audit["treatment"]["system_status"] = "operational_tested"
+        audit["quality"]["potability_status"] = "authority_verified"
+        audit["continuity"]["outage_test"] = "pass"
+        audit["continuity"]["field_test_duration_hours"] = 48
+        result = assess_water_verification(audit)
+        self.assertTrue(result["continuous_source_candidate"])
+        self.assertEqual(result["minimum_demonstrated_continuity_days"], 2.0)
+        self.assertIsNone(result["storage_autonomy_days"])
+
+    def test_audited_requires_review_and_no_critical_unbacked_dependencies(self):
+        audit = base_audit()
+        audit["hydraulics"]["usable_storage_liters"] = 1000
+        audit["continuity"]["daily_demand_liters"] = 100
+        audit["power"]["outage_extraction_test"] = "pass"
+        audit["treatment"]["system_status"] = "operational_tested"
+        audit["quality"]["potability_status"] = "lab_verified"
+        audit["continuity"]["outage_test"] = "pass"
+        audit["continuity"]["field_test_duration_hours"] = 24
+        audit["maintenance_status"] = "current"
+        audit["independent_review_completed"] = True
+        audit["dependencies"] = [{
+            "dependency_id": "backup-power",
+            "kind": "power",
+            "critical": True,
+            "backup_status": "ready",
+        }]
+        result = assess_water_verification(audit)
+        self.assertEqual(result["recommended_verification_status"], "audited")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #12

## What this adds

- Water Resilience Audit schema
- Water Verification Assessment schema
- Verification ladder: stated / measured / field_tested / audited
- Fail-closed potability gate
- Outage extraction / continuity gate
- Storage autonomy calculation only when storage + demand are defensible
- Continuous-source candidate flag without infinite-autonomy claims
- Synthetic examples
- Deterministic tests
- Schema semantic checks

## Safety invariants

- Well ownership does not establish potable water.
- TDS / consumer sensors do not establish potability.
- PV ownership does not establish outage extraction.
- Continuous flow does not become infinite autonomy.
- Field-tested status requires real outage/degraded-mode evidence.
- Audited status requires review, maintenance, evidence, and backed critical dependencies.

No real private site values are included in this public PR.
