### PR TITLE
Water v0.1.1: explicit unknown states

### DIFF
--- a/docs/WATER-RESILIENCE-VERIFICATION.md
+++ b/docs/WATER-RESILIENCE-VERIFICATION.md
@@ -8,7 +8,7 @@
 
 `Source → Extraction → Power → Storage → Treatment → Quality → Distribution → Maintenance/Spares → Outage Test`
 
-任何关键环节未知，都会限制验证等级。
+任何关键环节未知，都会限制验证等级。对 extraction power requirement 和 treatment requirement 这类尚未确认的事实，允许显式记录为 `null/unknown`，不得为了通过 schema 强行填写 true/false。
 
 ## Verification ladder
 

--- a/schemas/water-resilience-audit.schema.json
+++ b/schemas/water-resilience-audit.schema.json
@@ -151,7 +151,10 @@
       ],
       "properties": {
         "extraction_requires_power": {
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "primary_power": {
           "enum": [
@@ -192,7 +195,10 @@
       ],
       "properties": {
         "required": {
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "system_status": {
           "enum": [

--- a/src/psrro/water.py
+++ b/src/psrro/water.py
@@ -36,20 +36,27 @@ def assess_water_verification(audit: Mapping) -> dict:
     if quality.get("consumer_sensor_only") and potability_required:
         blockers.append("consumer sensors do not establish potability")
 
-    extraction_power_gate = (
-        not power["extraction_requires_power"]
-        or power["outage_extraction_test"] == "pass"
-        or power["primary_power"] == "manual"
-    )
+    extraction_requires_power = power["extraction_requires_power"]
+    if extraction_requires_power is None:
+        blockers.append("extraction power requirement unknown")
+        extraction_power_gate = False
+    else:
+        extraction_power_gate = (
+            not extraction_requires_power
+            or power["outage_extraction_test"] == "pass"
+            or power["primary_power"] == "manual"
+        )
     outage_gate = continuity["outage_test"] == "pass" and extraction_power_gate
 
-    if power["extraction_requires_power"] and power["outage_extraction_test"] != "pass":
+    if extraction_requires_power is True and power["outage_extraction_test"] != "pass":
         blockers.append("outage extraction path not demonstrated")
 
     if potability_required and not potability_gate:
         blockers.append("potability not independently verified")
 
-    if potability_required and treatment["required"] and treatment["system_status"] != "operational_tested":
+    if potability_required and treatment["required"] is None:
+        blockers.append("treatment requirement unknown")
+    if potability_required and treatment["required"] is True and treatment["system_status"] != "operational_tested":
         blockers.append("required treatment path not operationally tested")
 
     storage = hydraulics.get("usable_storage_liters")
@@ -80,9 +87,19 @@ def assess_water_verification(audit: Mapping) -> dict:
     else:
         status = "measured"
 
-    if status == "measured" and outage_gate and (potability_gate or not potability_required):
-        if not (potability_required and treatment["required"] and treatment["system_status"] != "operational_tested"):
-            status = "field_tested"
+    treatment_gate = (
+        not potability_required
+        or (
+            treatment["required"] is False
+            or (
+                treatment["required"] is True
+                and treatment["system_status"] == "operational_tested"
+            )
+        )
+    )
+
+    if status == "measured" and outage_gate and (potability_gate or not potability_required) and treatment_gate:
+        status = "field_tested"
 
     if (
         status == "field_tested"

--- a/tests/test_water.py
+++ b/tests/test_water.py
@@ -50,6 +50,29 @@ class WaterVerificationTests(unittest.TestCase):
         self.assertEqual(result["recommended_verification_status"], "stated")
         self.assertIsNone(result["storage_autonomy_days"])
 
+    def test_unknown_extraction_power_requirement_fails_closed(self):
+        audit = base_audit()
+        audit["power"]["extraction_requires_power"] = None
+        audit["hydraulics"]["usable_storage_liters"] = 1000
+        result = assess_water_verification(audit)
+        self.assertEqual(result["recommended_verification_status"], "measured")
+        self.assertFalse(result["outage_gate_passed"])
+        self.assertIn("extraction power requirement unknown", result["blockers"])
+
+    def test_unknown_treatment_requirement_blocks_field_tested(self):
+        audit = base_audit()
+        audit["treatment"]["required"] = None
+        audit["hydraulics"]["usable_storage_liters"] = 1000
+        audit["quality"]["potability_status"] = "lab_verified"
+        audit["quality"]["evidence_date"] = "2026-08-30"
+        audit["quality"]["evidence_ref"] = "synthetic-lab"
+        audit["power"]["outage_extraction_test"] = "pass"
+        audit["continuity"]["outage_test"] = "pass"
+        audit["continuity"]["field_test_duration_hours"] = 24
+        result = assess_water_verification(audit)
+        self.assertEqual(result["recommended_verification_status"], "measured")
+        self.assertIn("treatment requirement unknown", result["blockers"])
+
     def test_measured_storage_does_not_become_field_tested(self):
         audit = base_audit()
         audit["hydraulics"]["usable_storage_liters"] = 1000


### PR DESCRIPTION
Closes #14

## Fix

- Allow `power.extraction_requires_power = null`
- Allow `treatment.required = null`
- Treat both as unknown/fail-closed
- Prevent field_tested upgrade while either relevant requirement is unknown
- Add regression tests
- Document explicit unknown-state discipline

## Principle

Unknown stays unknown. The schema must never pressure operators to invent facts.
