### PR TITLE
Phase 3C-ENERGY: energy resilience verification v0.1

### DIFF
--- a/docs/ENERGY-RESILIENCE-VERIFICATION.md
+++ b/docs/ENERGY-RESILIENCE-VERIFICATION.md
@@ -1,0 +1,82 @@
+# Energy Resilience Verification v0.1
+
+## Core principle
+
+`PV present ≠ outage power`  
+`Battery nameplate ≠ usable energy`  
+`Inverter present ≠ islanding`  
+`Islanding ≠ black-start`
+
+Energy resilience is the ability to keep **defined critical loads** operating after normal external power is lost.
+
+## Verification chain
+
+`Generation → Storage → Conversion/Transfer → Critical Loads → Islanding → Black Start → Outage Test → Maintenance/Spares`
+
+## Verification ladder
+
+### stated
+Assets are reported/present, but there is no defensible measured usable capacity or load baseline.
+
+### measured
+At least one relevant usable quantity is measured:
+- PV delivered/peak output;
+- usable battery kWh;
+- battery continuous output;
+- critical peak load;
+- critical daily energy;
+- measured outage energy served.
+
+Nameplate-only PV/battery figures are not enough to establish resilience.
+
+### field_tested
+Requires:
+- outage test passes for a positive duration;
+- islanding is tested or genuinely not applicable;
+- black-start is tested or genuinely not applicable;
+- critical loads are mapped;
+- critical daily energy is known;
+- essential circuits are actually tested.
+
+### audited
+Field-tested plus:
+- evidence complete;
+- maintenance current;
+- independent review;
+- no unresolved SPOF;
+- critical dependencies have a ready/not-required backup.
+
+## Storage autonomy
+
+When usable battery energy and critical daily demand are both defensible:
+
+`storage_autonomy_days = usable_kWh / critical_kWh_per_day`
+
+This is storage-only autonomy. It does not include future solar production unless the scenario model explicitly validates generation and weather assumptions.
+
+## Renewable sustaining candidate
+
+PV can be marked as a sustaining candidate only when:
+- measured PV output exists;
+- islanding works;
+- black-start works;
+- outage test passes;
+- critical loads are known.
+
+Even then, the system does not assign infinite autonomy. Renewable output varies with weather, season, equipment condition and load.
+
+## Field evidence
+
+Collect:
+1. PV/inverter/battery/generator inventory and nameplates
+2. actual system topology
+3. islanding capability
+4. black-start capability
+5. usable battery kWh and power limit
+6. critical-load inventory and measured demand
+7. generator/fuel path if present
+8. controlled outage-test result
+9. inverter/BMS/controller/network dependencies
+10. spares and maintenance
+
+Electrical-panel inspection, switching and controlled grid-loss tests should be performed by qualified personnel under a safe site procedure.

--- a/examples/synthetic/energy-resilience-audit.json
+++ b/examples/synthetic/energy-resilience-audit.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "0.1.0",
+  "energy_audit_id": "era-synthetic-001",
+  "capability_id": "cap-synthetic-energy",
+  "service_scope": "critical_loads",
+  "grid": {
+    "connection_status": "connected",
+    "normal_operation_depends_on_grid": true
+  },
+  "generation": {
+    "pv_present": true,
+    "pv_nameplate_kwp": 100,
+    "pv_measured_peak_kw": 75,
+    "generator_present": false,
+    "generator_rated_kw": null,
+    "generator_measured_runtime_hours": null
+  },
+  "storage": {
+    "battery_present": true,
+    "nameplate_kwh": 120,
+    "usable_kwh": 100,
+    "max_continuous_output_kw": 40
+  },
+  "conversion": {
+    "inverter_present": true,
+    "islanding_status": "tested_pass",
+    "black_start_status": "tested_pass",
+    "transfer_path_status": "tested_pass"
+  },
+  "loads": {
+    "critical_loads_mapped": true,
+    "critical_peak_kw": 20,
+    "critical_energy_kwh_per_day": 50,
+    "essential_circuits_tested": true
+  },
+  "outage_test": {
+    "status": "pass",
+    "duration_hours": 24,
+    "minimum_load_served_kw": 10,
+    "energy_served_kwh": 45
+  },
+  "dependencies": [
+    {
+      "dependency_id": "critical-inverter",
+      "kind": "inverter",
+      "critical": true,
+      "backup_status": "ready"
+    }
+  ],
+  "single_points_of_failure": [],
+  "maintenance_status": "current",
+  "independent_review_completed": false,
+  "evidence_refs": [
+    "synthetic-meter",
+    "synthetic-outage"
+  ],
+  "updated_at": "2026-08-31T00:00:00Z",
+  "data_sensitivity": "public"
+}

--- a/examples/synthetic/energy-verification-assessment.json
+++ b/examples/synthetic/energy-verification-assessment.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "0.1.0",
+  "assessment_id": "eva-synthetic-001",
+  "energy_audit_id": "era-synthetic-001",
+  "recommended_verification_status": "field_tested",
+  "islanding_gate_passed": true,
+  "black_start_gate_passed": true,
+  "critical_load_gate_passed": true,
+  "storage_autonomy_days": 2,
+  "minimum_demonstrated_continuity_days": 1,
+  "renewable_sustaining_candidate": true,
+  "backup_generation_candidate": false,
+  "blockers": [],
+  "as_of": "2026-08-31T00:00:00Z",
+  "sensitivity": "public"
+}

--- a/schemas/energy-resilience-audit.schema.json
+++ b/schemas/energy-resilience-audit.schema.json
@@ -1,0 +1,376 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/energy-resilience-audit.schema.json",
+  "title": "Energy Resilience Audit",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "energy_audit_id",
+    "capability_id",
+    "service_scope",
+    "grid",
+    "generation",
+    "storage",
+    "conversion",
+    "loads",
+    "outage_test",
+    "dependencies",
+    "single_points_of_failure",
+    "maintenance_status",
+    "independent_review_completed",
+    "evidence_refs",
+    "updated_at",
+    "data_sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "energy_audit_id": {
+      "type": "string",
+      "pattern": "^era-[A-Za-z0-9._-]+$"
+    },
+    "capability_id": {
+      "type": "string",
+      "pattern": "^cap-[A-Za-z0-9._-]+$"
+    },
+    "service_scope": {
+      "enum": [
+        "unknown",
+        "critical_loads",
+        "partial_site",
+        "whole_site"
+      ]
+    },
+    "grid": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "connection_status",
+        "normal_operation_depends_on_grid"
+      ],
+      "properties": {
+        "connection_status": {
+          "enum": [
+            "unknown",
+            "connected",
+            "disconnected",
+            "not_applicable"
+          ]
+        },
+        "normal_operation_depends_on_grid": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "generation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pv_present",
+        "pv_nameplate_kwp",
+        "pv_measured_peak_kw",
+        "generator_present",
+        "generator_rated_kw",
+        "generator_measured_runtime_hours"
+      ],
+      "properties": {
+        "pv_present": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "pv_nameplate_kwp": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "pv_measured_peak_kw": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "generator_present": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "generator_rated_kw": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "generator_measured_runtime_hours": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        }
+      }
+    },
+    "storage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "battery_present",
+        "nameplate_kwh",
+        "usable_kwh",
+        "max_continuous_output_kw"
+      ],
+      "properties": {
+        "battery_present": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "nameplate_kwh": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "usable_kwh": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "max_continuous_output_kw": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        }
+      }
+    },
+    "conversion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "inverter_present",
+        "islanding_status",
+        "black_start_status",
+        "transfer_path_status"
+      ],
+      "properties": {
+        "inverter_present": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "islanding_status": {
+          "enum": [
+            "unknown",
+            "not_capable",
+            "capable_unverified",
+            "tested_pass",
+            "tested_fail",
+            "not_applicable"
+          ]
+        },
+        "black_start_status": {
+          "enum": [
+            "unknown",
+            "not_supported",
+            "unverified",
+            "tested_pass",
+            "tested_fail",
+            "not_applicable"
+          ]
+        },
+        "transfer_path_status": {
+          "enum": [
+            "unknown",
+            "absent",
+            "present_unverified",
+            "tested_pass",
+            "tested_fail",
+            "not_applicable"
+          ]
+        }
+      }
+    },
+    "loads": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "critical_loads_mapped",
+        "critical_peak_kw",
+        "critical_energy_kwh_per_day",
+        "essential_circuits_tested"
+      ],
+      "properties": {
+        "critical_loads_mapped": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "critical_peak_kw": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "critical_energy_kwh_per_day": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "exclusiveMinimum": 0
+        },
+        "essential_circuits_tested": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "outage_test": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "duration_hours",
+        "minimum_load_served_kw",
+        "energy_served_kwh"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "not_run",
+            "pass",
+            "partial",
+            "fail"
+          ]
+        },
+        "duration_hours": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "minimum_load_served_kw": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "energy_served_kwh": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        }
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "dependency_id",
+          "kind",
+          "critical",
+          "backup_status"
+        ],
+        "properties": {
+          "dependency_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "kind": {
+            "enum": [
+              "grid",
+              "solar",
+              "battery",
+              "inverter",
+              "generator",
+              "fuel",
+              "control",
+              "network",
+              "personnel",
+              "spares",
+              "other"
+            ]
+          },
+          "critical": {
+            "type": "boolean"
+          },
+          "backup_status": {
+            "enum": [
+              "none",
+              "partial",
+              "ready",
+              "unknown",
+              "not_required"
+            ]
+          }
+        }
+      }
+    },
+    "single_points_of_failure": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "maintenance_status": {
+      "enum": [
+        "current",
+        "due",
+        "overdue",
+        "unknown"
+      ]
+    },
+    "independent_review_completed": {
+      "type": "boolean"
+    },
+    "evidence_refs": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "data_sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/energy-verification-assessment.schema.json
+++ b/schemas/energy-verification-assessment.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/energy-verification-assessment.schema.json",
+  "title": "Energy Verification Assessment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "assessment_id",
+    "energy_audit_id",
+    "recommended_verification_status",
+    "islanding_gate_passed",
+    "black_start_gate_passed",
+    "critical_load_gate_passed",
+    "storage_autonomy_days",
+    "minimum_demonstrated_continuity_days",
+    "renewable_sustaining_candidate",
+    "backup_generation_candidate",
+    "blockers",
+    "as_of",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "assessment_id": {
+      "type": "string",
+      "pattern": "^eva-[A-Za-z0-9._-]+$"
+    },
+    "energy_audit_id": {
+      "type": "string",
+      "pattern": "^era-[A-Za-z0-9._-]+$"
+    },
+    "recommended_verification_status": {
+      "enum": [
+        "stated",
+        "measured",
+        "field_tested",
+        "audited"
+      ]
+    },
+    "islanding_gate_passed": {
+      "type": "boolean"
+    },
+    "black_start_gate_passed": {
+      "type": "boolean"
+    },
+    "critical_load_gate_passed": {
+      "type": "boolean"
+    },
+    "storage_autonomy_days": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "minimum_demonstrated_continuity_days": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "renewable_sustaining_candidate": {
+      "type": "boolean"
+    },
+    "backup_generation_candidate": {
+      "type": "boolean"
+    },
+    "blockers": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "as_of": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/scripts/validate_schemas.py
+++ b/scripts/validate_schemas.py
@@ -21,6 +21,8 @@ PAIRS = {
     "preparedness_snapshot": ("schemas/preparedness-snapshot.schema.json", "examples/synthetic/preparedness-snapshot.json"),
     "water_resilience_audit": ("schemas/water-resilience-audit.schema.json", "examples/synthetic/water-resilience-audit.json"),
     "water_verification_assessment": ("schemas/water-verification-assessment.schema.json", "examples/synthetic/water-verification-assessment.json"),
+    "energy_resilience_audit": ("schemas/energy-resilience-audit.schema.json", "examples/synthetic/energy-resilience-audit.json"),
+    "energy_verification_assessment": ("schemas/energy-verification-assessment.schema.json", "examples/synthetic/energy-verification-assessment.json"),
 }
 
 def load(path):
@@ -74,6 +76,27 @@ def semantic_errors(name, obj):
         if continuity["outage_test"] == "pass":
             if not continuity.get("field_test_duration_hours") or continuity["field_test_duration_hours"] <= 0:
                 errors.append("passed outage test requires positive field_test_duration_hours")
+    elif name == "energy_resilience_audit":
+        storage = obj["storage"]
+        if storage["nameplate_kwh"] is not None and storage["usable_kwh"] is not None:
+            if storage["usable_kwh"] > storage["nameplate_kwh"]:
+                errors.append("usable battery kWh cannot exceed nameplate kWh")
+        if storage["battery_present"] is False:
+            if any(storage[key] is not None for key in ("nameplate_kwh", "usable_kwh", "max_continuous_output_kw")):
+                errors.append("battery_present=false conflicts with battery capacity values")
+        generation = obj["generation"]
+        if generation["pv_present"] is False and (
+            generation["pv_nameplate_kwp"] is not None or generation["pv_measured_peak_kw"] is not None
+        ):
+            errors.append("pv_present=false conflicts with PV capacity values")
+        if generation["generator_present"] is False and (
+            generation["generator_rated_kw"] is not None or generation["generator_measured_runtime_hours"] is not None
+        ):
+            errors.append("generator_present=false conflicts with generator values")
+        outage = obj["outage_test"]
+        if outage["status"] == "pass":
+            if not outage.get("duration_hours") or outage["duration_hours"] <= 0:
+                errors.append("passed outage test requires positive duration_hours")
     return errors
 
 def main():

--- a/src/psrro/__init__.py
+++ b/src/psrro/__init__.py
@@ -1,3 +1,4 @@
+from .energy import assess_energy_verification
 from .water import assess_water_verification
 from .preparedness import preparedness_snapshot
 from .quantification import (
@@ -10,6 +11,7 @@ from .quantification import (
 )
 
 __all__ = [
+    "assess_energy_verification",
     "assess_water_verification",
     "preparedness_snapshot",
     "buffer_floor_days",

--- a/src/psrro/energy.py
+++ b/src/psrro/energy.py
@@ -1,0 +1,143 @@
+"""Energy resilience verification v0.1.
+
+Nameplate assets are not outage capability. This module separates measured
+capacity, islanding, black-start, critical-load knowledge and demonstrated
+continuity. Renewable generation never becomes an infinite-autonomy claim.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def assess_energy_verification(audit: Mapping) -> dict:
+    blockers: list[str] = []
+    generation = audit["generation"]
+    storage = audit["storage"]
+    conversion = audit["conversion"]
+    loads = audit["loads"]
+    outage = audit["outage_test"]
+
+    asset_present = any(
+        value is True
+        for value in (
+            generation["pv_present"],
+            generation["generator_present"],
+            storage["battery_present"],
+            conversion["inverter_present"],
+        )
+    )
+
+    measured_capacity = any(
+        value is not None
+        for value in (
+            generation["pv_measured_peak_kw"],
+            storage["usable_kwh"],
+            storage["max_continuous_output_kw"],
+            loads["critical_peak_kw"],
+            loads["critical_energy_kwh_per_day"],
+            outage["energy_served_kwh"],
+        )
+    )
+
+    islanding_gate = conversion["islanding_status"] in {"tested_pass", "not_applicable"}
+    black_start_gate = conversion["black_start_status"] in {"tested_pass", "not_applicable"}
+    critical_load_gate = (
+        loads["critical_loads_mapped"] is True
+        and loads["critical_energy_kwh_per_day"] is not None
+    )
+
+    if conversion["islanding_status"] in {"unknown", "capable_unverified"}:
+        blockers.append("islanding capability not demonstrated")
+    elif conversion["islanding_status"] in {"not_capable", "tested_fail"}:
+        blockers.append("islanding capability unavailable or failed")
+
+    if conversion["black_start_status"] in {"unknown", "unverified"}:
+        blockers.append("black-start capability not demonstrated")
+    elif conversion["black_start_status"] in {"not_supported", "tested_fail"}:
+        blockers.append("black-start capability unavailable or failed")
+
+    if not critical_load_gate:
+        blockers.append("critical-load demand baseline incomplete")
+
+    if loads["essential_circuits_tested"] is not True:
+        blockers.append("essential circuits not field tested")
+
+    storage_days = None
+    if storage["usable_kwh"] is not None and loads["critical_energy_kwh_per_day"] is not None:
+        storage_days = storage["usable_kwh"] / loads["critical_energy_kwh_per_day"]
+
+    demonstrated_days = None
+    if outage["status"] == "pass" and outage["duration_hours"] is not None:
+        demonstrated_days = outage["duration_hours"] / 24.0
+
+    renewable_candidate = bool(
+        generation["pv_present"] is True
+        and generation["pv_measured_peak_kw"] is not None
+        and generation["pv_measured_peak_kw"] > 0
+        and islanding_gate
+        and black_start_gate
+        and outage["status"] == "pass"
+        and critical_load_gate
+    )
+
+    backup_generation_candidate = bool(
+        generation["generator_present"] is True
+        and generation["generator_rated_kw"] is not None
+        and generation["generator_rated_kw"] > 0
+        and outage["status"] == "pass"
+        and black_start_gate
+    )
+
+    if not asset_present:
+        blockers.append("no resilience energy asset confirmed")
+        status = "stated"
+    elif not measured_capacity:
+        blockers.append("no measured usable capacity or critical-load demand")
+        status = "stated"
+    else:
+        status = "measured"
+
+    outage_gate = (
+        outage["status"] == "pass"
+        and outage["duration_hours"] is not None
+        and outage["duration_hours"] > 0
+        and islanding_gate
+        and black_start_gate
+        and critical_load_gate
+        and loads["essential_circuits_tested"] is True
+    )
+
+    if status == "measured" and outage_gate:
+        status = "field_tested"
+
+    if (
+        status == "field_tested"
+        and audit["independent_review_completed"]
+        and audit["maintenance_status"] == "current"
+        and audit["evidence_refs"]
+        and not audit["single_points_of_failure"]
+        and all(
+            dep["backup_status"] not in {"none", "unknown"}
+            for dep in audit["dependencies"]
+            if dep["critical"]
+        )
+    ):
+        status = "audited"
+
+    return {
+        "schema_version": "0.1.0",
+        "assessment_id": f"eva-{audit['energy_audit_id'][4:]}",
+        "energy_audit_id": audit["energy_audit_id"],
+        "recommended_verification_status": status,
+        "islanding_gate_passed": islanding_gate,
+        "black_start_gate_passed": black_start_gate,
+        "critical_load_gate_passed": critical_load_gate,
+        "storage_autonomy_days": None if storage_days is None else round(storage_days, 6),
+        "minimum_demonstrated_continuity_days": None if demonstrated_days is None else round(demonstrated_days, 6),
+        "renewable_sustaining_candidate": renewable_candidate,
+        "backup_generation_candidate": backup_generation_candidate,
+        "blockers": sorted(set(blockers)),
+        "as_of": audit["updated_at"],
+        "sensitivity": audit["data_sensitivity"],
+    }

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -1,0 +1,153 @@
+import unittest
+
+from src.psrro.energy import assess_energy_verification
+
+
+def base_audit():
+    return {
+        "schema_version": "0.1.0",
+        "energy_audit_id": "era-synthetic",
+        "capability_id": "cap-synthetic-energy",
+        "service_scope": "critical_loads",
+        "grid": {
+            "connection_status": "connected",
+            "normal_operation_depends_on_grid": True,
+        },
+        "generation": {
+            "pv_present": True,
+            "pv_nameplate_kwp": 100,
+            "pv_measured_peak_kw": None,
+            "generator_present": False,
+            "generator_rated_kw": None,
+            "generator_measured_runtime_hours": None,
+        },
+        "storage": {
+            "battery_present": None,
+            "nameplate_kwh": None,
+            "usable_kwh": None,
+            "max_continuous_output_kw": None,
+        },
+        "conversion": {
+            "inverter_present": True,
+            "islanding_status": "unknown",
+            "black_start_status": "unknown",
+            "transfer_path_status": "unknown",
+        },
+        "loads": {
+            "critical_loads_mapped": None,
+            "critical_peak_kw": None,
+            "critical_energy_kwh_per_day": None,
+            "essential_circuits_tested": None,
+        },
+        "outage_test": {
+            "status": "not_run",
+            "duration_hours": None,
+            "minimum_load_served_kw": None,
+            "energy_served_kwh": None,
+        },
+        "dependencies": [],
+        "single_points_of_failure": [],
+        "maintenance_status": "unknown",
+        "independent_review_completed": False,
+        "evidence_refs": ["synthetic"],
+        "updated_at": "2026-08-31T00:00:00Z",
+        "data_sensitivity": "public",
+    }
+
+
+class EnergyVerificationTests(unittest.TestCase):
+    def test_pv_nameplate_only_remains_stated(self):
+        result = assess_energy_verification(base_audit())
+        self.assertEqual(result["recommended_verification_status"], "stated")
+        self.assertFalse(result["islanding_gate_passed"])
+        self.assertIsNone(result["storage_autonomy_days"])
+
+    def test_measured_storage_calculates_storage_autonomy_only(self):
+        audit = base_audit()
+        audit["storage"]["battery_present"] = True
+        audit["storage"]["usable_kwh"] = 100
+        audit["loads"]["critical_loads_mapped"] = True
+        audit["loads"]["critical_energy_kwh_per_day"] = 50
+        result = assess_energy_verification(audit)
+        self.assertEqual(result["recommended_verification_status"], "measured")
+        self.assertEqual(result["storage_autonomy_days"], 2.0)
+        self.assertIsNone(result["minimum_demonstrated_continuity_days"])
+
+    def test_grid_tied_pv_without_islanding_is_not_field_tested(self):
+        audit = base_audit()
+        audit["generation"]["pv_measured_peak_kw"] = 80
+        audit["conversion"]["islanding_status"] = "not_capable"
+        audit["conversion"]["black_start_status"] = "not_supported"
+        audit["loads"]["critical_loads_mapped"] = True
+        audit["loads"]["critical_energy_kwh_per_day"] = 50
+        audit["loads"]["essential_circuits_tested"] = True
+        audit["outage_test"]["status"] = "fail"
+        result = assess_energy_verification(audit)
+        self.assertEqual(result["recommended_verification_status"], "measured")
+        self.assertFalse(result["renewable_sustaining_candidate"])
+
+    def test_field_tested_requires_islanding_black_start_and_critical_loads(self):
+        audit = base_audit()
+        audit["generation"]["pv_measured_peak_kw"] = 80
+        audit["storage"]["battery_present"] = True
+        audit["storage"]["usable_kwh"] = 100
+        audit["storage"]["max_continuous_output_kw"] = 40
+        audit["conversion"]["islanding_status"] = "tested_pass"
+        audit["conversion"]["black_start_status"] = "tested_pass"
+        audit["conversion"]["transfer_path_status"] = "tested_pass"
+        audit["loads"]["critical_loads_mapped"] = True
+        audit["loads"]["critical_peak_kw"] = 20
+        audit["loads"]["critical_energy_kwh_per_day"] = 50
+        audit["loads"]["essential_circuits_tested"] = True
+        audit["outage_test"]["status"] = "pass"
+        audit["outage_test"]["duration_hours"] = 24
+        audit["outage_test"]["minimum_load_served_kw"] = 10
+        audit["outage_test"]["energy_served_kwh"] = 45
+        result = assess_energy_verification(audit)
+        self.assertEqual(result["recommended_verification_status"], "field_tested")
+        self.assertEqual(result["storage_autonomy_days"], 2.0)
+        self.assertEqual(result["minimum_demonstrated_continuity_days"], 1.0)
+        self.assertTrue(result["renewable_sustaining_candidate"])
+
+    def test_renewable_candidate_is_not_infinite_autonomy(self):
+        audit = base_audit()
+        audit["generation"]["pv_measured_peak_kw"] = 80
+        audit["conversion"]["islanding_status"] = "tested_pass"
+        audit["conversion"]["black_start_status"] = "tested_pass"
+        audit["loads"]["critical_loads_mapped"] = True
+        audit["loads"]["critical_energy_kwh_per_day"] = 40
+        audit["loads"]["essential_circuits_tested"] = True
+        audit["outage_test"]["status"] = "pass"
+        audit["outage_test"]["duration_hours"] = 48
+        audit["outage_test"]["energy_served_kwh"] = 60
+        result = assess_energy_verification(audit)
+        self.assertTrue(result["renewable_sustaining_candidate"])
+        self.assertIsNone(result["storage_autonomy_days"])
+        self.assertEqual(result["minimum_demonstrated_continuity_days"], 2.0)
+
+    def test_audited_requires_review_maintenance_and_backed_dependencies(self):
+        audit = base_audit()
+        audit["storage"]["battery_present"] = True
+        audit["storage"]["usable_kwh"] = 100
+        audit["conversion"]["islanding_status"] = "tested_pass"
+        audit["conversion"]["black_start_status"] = "tested_pass"
+        audit["loads"]["critical_loads_mapped"] = True
+        audit["loads"]["critical_energy_kwh_per_day"] = 50
+        audit["loads"]["essential_circuits_tested"] = True
+        audit["outage_test"]["status"] = "pass"
+        audit["outage_test"]["duration_hours"] = 24
+        audit["outage_test"]["energy_served_kwh"] = 40
+        audit["maintenance_status"] = "current"
+        audit["independent_review_completed"] = True
+        audit["dependencies"] = [{
+            "dependency_id": "critical-inverter",
+            "kind": "inverter",
+            "critical": True,
+            "backup_status": "ready",
+        }]
+        result = assess_energy_verification(audit)
+        self.assertEqual(result["recommended_verification_status"], "audited")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #16

## What this adds

- Energy Resilience Audit schema
- Energy Verification Assessment schema
- stated / measured / field_tested / audited ladder
- explicit islanding / black-start / critical-load gates
- storage-only autonomy calculation
- minimum demonstrated continuity from real outage tests
- renewable sustaining candidate without infinite-autonomy claims
- backup-generation candidate
- semantic validation for contradictory asset/capacity states
- deterministic tests

## Safety invariants

- PV present != outage power
- battery nameplate != usable energy
- inverter present != islanding
- islanding != black-start
- generator present != available fuel/runtime
- no unsafe panel/grid-isolation work by unqualified personnel
- no real private site values in this public PR
