### PR TITLE
Docs: prioritize Phase 3R radar precision upgrade

### DIFF
--- a/docs/INTELLIGENCE-ENGINE.md
+++ b/docs/INTELLIGENCE-ENGINE.md
@@ -1,8 +1,18 @@
-# World Intelligence Engine — Draft 0.2
+# World Intelligence Engine — Radar Precision Upgrade v0.1
 
 ## Objective
 
 精准捕捉“改变判断”的全球事件，而不是制造坏消息流。
+
+现有新闻推送对话继续作为用户前台。升级重点放在后台判断、状态记忆、去重、耦合变化与精准告警。
+
+## Preserve
+
+- P0 / P1 / P2
+- Physical AI Radar
+- 前台简洁结论
+- 后台 Evidence · Behavior · Systems
+- “没有改变判断的新闻，不应该打扰用户”
 
 ## Input domains
 
@@ -15,20 +25,80 @@
 - 社会动荡、治理变化
 - Physical AI Radar
 
-## Processing pipeline
+## Target pipeline
 
-Discovery → Dedup → Source Quality → Claim Split → Fact/Forecast/Correlation/Causality → Cross-source Verification → Four-Source Mapping → Edge Update → Scenario Update → Exposure Update → Alert Gate
+Discovery
+→ Event Fingerprint / Dedup
+→ Source Quality / Provenance
+→ Claim Split
+→ Fact / Forecast / Correlation / Causality / Opinion
+→ Behavior vs Rhetoric
+→ Counterevidence / Falsification
+→ Four-Source Mapping (A/B/C/D)
+→ Edge Delta
+→ Coupling Delta
+→ Buffer Delta
+→ Scenario Delta
+→ Personal Exposure / Lead-Time Delta
+→ Alert Gate
+→ Existing news-push conversation
 
-## Precision gate
+## Precision alert gate
 
-只有以下情况默认主动通知：
-- P0 事件；
+默认只在以下条件之一成立时通知：
+- P0 must-know 事件；
 - 多环节同步恶化；
-- Coupling Density 明显改变；
-- 新闭环候选形成；
-- 风险等级改变；
+- 新的或更强 validated edge；
+- Coupling Density 有实质改变；
+- feedback-loop candidate 强化/削弱；
+- Buffer 明显耗尽或恢复；
+- Scenario probability / velocity / Lead Time 有实质变化；
+- Global Stage / Personal R-Level 改变；
 - 关键假设被证伪；
-- Lead Time 明显缩短；
 - Action Playbook 需要改变。
 
-若无实质变化，不通知。
+其余更新进入状态存储，不主动打扰。
+
+## Alert suppression
+
+必须具备：
+- duplicate suppression
+- update-vs-new-event detection
+- cooldown
+- material-change threshold
+- hysteresis around thresholds
+- explicit “no substantive change = no notification”
+
+## Chain Watch v0.1
+
+第一条显式共振链：
+
+Climate / El Niño
+→ Food & Energy
+→ Inflation / Inflation Expectations
+→ Fed / Monetary Policy
+→ UST 10Y / 30Y + Financial Conditions / Fiscal Pressure
+→ AI CapEx / Tech Valuation / Financing Stress
+
+每一环必须区分：
+- Fact
+- Forecast
+- Correlation
+- Causality
+- Counterevidence
+
+输出的是链条状态变化，不是孤立头条。
+
+## Output contract
+
+前台告警回答：
+1. 发生了什么变化？
+2. 哪条边/链发生变化？
+3. 为什么重要？
+4. 哪些关键部分仍未证实？
+5. 有什么反证/缓冲？
+6. Global Stage 是否变化？
+7. Personal action 是否变化？
+8. 下一个升级/降级信号是什么？
+
+Keep concise.

--- a/docs/PROJECT-STATE.md
+++ b/docs/PROJECT-STATE.md
@@ -98,11 +98,24 @@ Principle:
 
 > **Open methodology, private exposure.**
 
-## Next engineering node
+## Current priority
 
-### Phase 3C — Capability Verification & Baseline Completion
+### Phase 3R — Radar Precision Upgrade v0.1
 
-Phase 3B has established a separate private operational-state layer and validated it against a pinned public method version.
+The existing news-push conversation remains the user-facing presentation layer. The current priority is to upgrade the backend World Intelligence Engine from conceptual Draft 0.2 into a stateful, precise systemic-risk radar before continuing deeper physical-capability audits.
+
+Priority focus:
+- source/evidence precision;
+- event fingerprinting and dedup;
+- behavior vs rhetoric;
+- counterevidence/falsification;
+- A/B/C/D edge and coupling deltas;
+- alert suppression/hysteresis;
+- first Chain Watch: climate→food/energy→inflation→Fed→UST/financial conditions→AI CapEx/valuation.
+
+### Phase 3C — Capability Verification & Baseline Completion — PAUSED AFTER CLEAN CHECKPOINT
+
+Phase 3B has established a separate private operational-state layer and validated it against a pinned public method version. Water baseline has been instantiated in private state; Water field evidence collection remains open. Energy verification method v0.1 is complete in the public method repository.
 
 The next task is to move private capabilities from `stated` toward `measured` / `field_tested` / `audited`, fill missing required domains, identify real single points of failure, and only then derive defensible Base Autonomy / First Failure Point.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,7 +38,19 @@
 ### Phase 3B — Private Operational State Bootstrap — COMPLETE
 Separate private operational-state layer established, pinned to public method version and validation-enabled.
 
-### Phase 3C — Capability Verification & Baseline Completion — NEXT
+### Phase 3R — Radar Precision Upgrade v0.1 — CURRENT PRIORITY
+
+- [ ] Source registry / source quality / provenance
+- [ ] Event fingerprint / clustering / dedup
+- [ ] Behavior vs rhetoric / directionality
+- [ ] Counterevidence / falsification
+- [ ] Edge / Coupling / Buffer / Scenario delta tracking
+- [ ] Alert gate / suppression / hysteresis
+- [ ] Chain Watch: climate→food/energy→inflation→Fed→UST/financial conditions→AI CapEx/valuation
+- [ ] Synthetic replay tests for duplicate, worsening, improvement, falsification
+- [ ] Existing news-push conversation retained as presentation layer
+
+### Phase 3C — Capability Verification & Baseline Completion — PAUSED AFTER CLEAN CHECKPOINT
 
 Private audit domains:
 - [ ] 现金流
@@ -46,8 +58,8 @@ Private audit domains:
 - [ ] 房产 / 资产处置
 - [ ] 工业空间 / 厂房
 - [ ] 土地 / 转换能力
-- [ ] 水源 / 净化 / 储水
-- [ ] 光伏 / 储能 / 离网能力
+- [~] 水源 / 净化 / 储水 — private baseline established; field evidence pending
+- [~] 光伏 / 储能 / 离网能力 — public verification method complete; private instantiation deferred until after Phase 3R
 - [ ] 车辆 / 机动
 - [ ] Physical AI / 防御性感知与巡检
 - [ ] 网络 / 通信 / 离线计算


### PR DESCRIPTION
Prioritizes Phase 3R — Radar Precision Upgrade v0.1 before deeper Phase 3C capability audits.

Changes:
- Project State: Phase 3R becomes CURRENT PRIORITY
- Roadmap: inserts Radar Precision workstream
- Intelligence Engine: upgrades Draft 0.2 plan to stateful radar design
- Existing news-push conversation remains the presentation layer
- Water field evidence and deeper capability audits remain tracked but paused at clean checkpoints

No private operational values are added.