### PR TITLE
Phase 3R-00: capture existing news radar baseline

### DIFF
--- a/adr/0006-preserve-existing-news-radar.md
+++ b/adr/0006-preserve-existing-news-radar.md
@@ -1,0 +1,30 @@
+# ADR-0006: Preserve Existing News Radar and Integrate Physical AI by Handoff
+
+Status: Accepted
+
+## Decision
+
+Preserve the existing news-push conversation as the user-facing intelligence product.
+
+Phase 3R upgrades the backend precision engine rather than replacing the presentation model.
+
+Physical AI remains a module inside the news product, but project-relevant Physical AI signals are handed off into the existing Physical AI Technology Radar rather than creating a second technical-radar authority.
+
+## Interface
+
+`News Radar / Physical AI module`
+→ verify / dedup / cluster / compress
+→ project-relevant handoff
+→ `TECH-RADAR-04 Observation Packet + human-reviewed admission`
+→ existing TECH-RADAR-01/02/03 governance
+
+## Invariants
+
+- P0/P1/P2 remains news attention priority.
+- TECH-RADAR-01 ASSESS/TRIAL/ADOPT/HOLD remains engineering decision state.
+- TECH-RADAR-04 REJECT/DEFER/WATCH/PROMOTE_TO_V1_RESEARCH/PROJECT_EVIDENCE_RECONCILIATION remains upstream admission routing.
+- WATCH is not ADOPT and is not a TECH-RADAR-01 state.
+- News discovery cannot grant engineering/physical authority.
+- Raw news streams do not enter the Physical AI engineering repository.
+- Existing front-end briefing behavior is preserved unless explicitly changed.
+- Future MD/spec reconciliation may refine this baseline without silent replacement.

--- a/docs/NEWS-RADAR-BASELINE.md
+++ b/docs/NEWS-RADAR-BASELINE.md
@@ -1,0 +1,174 @@
+# Existing News Radar Baseline — Phase 3R-00
+
+## Status
+
+Recovered operational baseline.
+
+This document captures the already-working news recommendation and briefing logic before Phase 3R precision upgrades. It is a preservation baseline, not a redesign.
+
+If an original Markdown specification is later supplied, reconcile it against this baseline and record differences explicitly.
+
+## 1. Product role
+
+The existing news conversation remains the primary user-facing intelligence surface.
+
+It covers:
+- domestic and international current affairs;
+- geopolitical competition;
+- military developments;
+- regional conflict;
+- macro / finance / trade / supply-chain developments;
+- climate / disasters / resource constraints;
+- Physical AI developments relevant to the user's project.
+
+The front end should remain conversational and direct. The backend may be much more complex.
+
+## 2. Recovered presentation behavior
+
+Operational preferences recovered from prior use:
+
+- primary delivery is a daily morning briefing around 08:00;
+- avoid duplicative evening briefing as a second default digest;
+- avoid a noisy hourly P0 presentation loop as a default user experience;
+- front-end analysis is intentionally compressed;
+- backend reasoning remains deep;
+- top-level daily judgments remain tightly bounded, historically around no more than three major judgments;
+- individual event items should emphasize:
+  1. what happened;
+  2. current judgment;
+  3. why it matters;
+  4. what to watch next.
+
+These are preserved operating preferences, not hard-coded scheduling infrastructure in this repository.
+
+## 3. P0 / P1 / P2
+
+P0 / P1 / P2 is an **intelligence priority taxonomy**, not the global systemic-risk stage and not the personal R-Level.
+
+### P0
+Must-know information because it may:
+- materially change model state;
+- materially shorten Lead Time;
+- alter a major scenario;
+- change an action/playbook;
+- invalidate an important assumption;
+- represent a single major event with immediate systemic relevance.
+
+P0 is not “dramatic headline”.
+
+### P1
+Important trend evidence worth retaining and incorporating into the model, but not necessarily requiring immediate interruption.
+
+### P2
+Background/context. Useful for state maintenance and understanding, but normally not worth interrupting the user.
+
+## 4. Backend reasoning contract
+
+The radar may use a full Evidence · Behavior · Systems reasoning chain internally.
+
+### Evidence
+- multi-source discovery;
+- claim splitting;
+- source quality / provenance;
+- primary vs secondary;
+- independent vs derivative sources;
+- fact / forecast / correlation / causality / opinion;
+- counterevidence;
+- confidence and uncertainty.
+
+### Behavior
+For political/military/state actors:
+- observable action may carry more evidentiary value than rhetoric;
+- words-actions gap is explicit;
+- logistics, mobilization, routing, procurement, deployment, regulation and market behavior may matter more than statements.
+
+### Systems
+- map events into first-order variables A/B/C/D;
+- track transmission edges;
+- avoid common-cause double counting;
+- update Coupling Density;
+- monitor feedback-loop candidates;
+- track buffer depletion/restoration;
+- update scenarios and Lead Time;
+- map personal exposure only after global-system judgment.
+
+## 5. Multi-risk resonance baseline
+
+The radar is not a “bad news counter”.
+
+A resonance alert becomes meaningful when:
+- multiple distinct risk domains synchronously deteriorate; or
+- one major event materially changes several downstream systems; or
+- an important transmission edge is strengthened/validated; or
+- a key buffer is depleted; or
+- the global risk structure changes.
+
+A prior operational threshold used “at least three risk categories visibly worsening together, or one major event”. Phase 3R may refine this into explicit structural-delta logic, but it should preserve the spirit: synchronized change matters more than headline count.
+
+## 6. Front-end compression
+
+The front end should not expose the entire backend reasoning chain.
+
+Default user-facing output should emphasize:
+- conclusion;
+- material evidence;
+- what changed;
+- why it matters;
+- uncertainty/counterevidence when decision-relevant;
+- next trigger.
+
+Detailed chain-of-thought style exposition is not required for normal alerts.
+
+## 7. Physical AI Radar
+
+Physical AI is a fixed intelligence module within the same user-facing news product.
+
+Coverage includes:
+- drones / UAVs;
+- quadrupeds / robot dogs;
+- UGVs;
+- humanoids;
+- manipulators;
+- biomimetic / insect-scale / micro robots;
+- AI vision / VLM / VLA / perception;
+- world models;
+- planning / control;
+- multi-agent / swarm / one-to-many supervision;
+- digital twins / simulation / data flywheels / RoboOps;
+- edge/local AI;
+- degraded/offline runtime;
+- autonomous inspection / security;
+- high-adversity field lessons from real unmanned systems, bounded to generalizable systems/robotics insight.
+
+The Physical AI Radar is not a separate news product. It is one domain inside the broader intelligence product, with a specialized downstream engineering path into the Physical AI project's Technology Radar.
+
+## 8. What Phase 3R may improve
+
+Phase 3R should improve:
+- source registry;
+- source independence;
+- event fingerprinting;
+- clustering/dedup;
+- novelty/change detection;
+- behavior-vs-rhetoric;
+- counterevidence/falsification;
+- edge/coupling/buffer/scenario deltas;
+- alert suppression/hysteresis;
+- Chain Watch.
+
+It should **not** casually replace:
+- P0/P1/P2;
+- the concise presentation style;
+- the existing daily briefing experience;
+- Physical AI Radar;
+- the principle that no substantive change means no notification.
+
+## 9. Reconciliation rule
+
+If an original news-radar Markdown/spec is supplied:
+1. parse it as a source artifact;
+2. compare against this recovered baseline;
+3. prefer later explicit user rules over older rules;
+4. record conflicts;
+5. preserve working behavior unless there is an explicit reason to change it;
+6. update this document through review rather than silent replacement.

--- a/docs/PHYSICAL-AI-RADAR-INTEGRATION.md
+++ b/docs/PHYSICAL-AI-RADAR-INTEGRATION.md
@@ -1,0 +1,176 @@
+# Physical AI Radar Integration Contract
+
+## Purpose
+
+Define how the general News / Systemic-Risk Radar and the existing Physical AI Technology Radar cooperate without creating duplicate taxonomies, duplicate news stores or duplicate engineering authority.
+
+## 1. Two acquisition paths, one Physical AI intake
+
+Physical AI signals may arrive through:
+
+### A. Active discovery
+The News / Radar system proactively discovers relevant Physical AI research, products, field signals, papers, platform movements or architecture lessons.
+
+### B. User-supplied external observation
+The user encounters an external video, article, paper, product or field case and submits it for analysis.
+
+Both paths converge into the same bounded Physical AI intake.
+
+`Active Discovery | User-Supplied Signal`
+→ verify
+→ deduplicate / normalize
+→ cluster
+→ compress to claims
+→ bounded Observation Packet
+→ Physical AI TECH-RADAR-04 admission/review
+
+The acquisition path must not create a second Technology Radar.
+
+## 2. Authoritative Physical AI radar layers
+
+Fresh-read of the Physical AI project establishes the following authoritative distinctions.
+
+### TECH-RADAR-01 — evidence / decision core
+
+Core Technology Radar decision states:
+- `ASSESS`
+- `TRIAL`
+- `ADOPT`
+- `HOLD`
+
+Engineering strategies:
+- `REUSE`
+- `ADAPT`
+- `EXTEND`
+- `BUILD`
+
+Authorization ladder remains separate:
+`RESEARCH < TRIAL < ADOPT < IMPLEMENT < PRODUCTION < PHYSICAL`
+
+No news/radar integration may widen these authorities.
+
+### TECH-RADAR-02 — Physical AI context model
+
+Adds context such as:
+- 道 / 法 / 术 / 器 / 势 / 士;
+- cross-cutting 智;
+- embodied intelligence;
+- physical bodies;
+- perception;
+- autonomy runtime;
+- multi-agent;
+- machine ecology;
+- Physical AI data;
+- Physical AI ops.
+
+It is contextual interpretation, not a parallel adoption authority.
+
+### TECH-RADAR-04 — new knowledge admission
+
+External/project observations enter through a bounded admission layer.
+
+Allowed upstream routes:
+- `REJECT`
+- `DEFER`
+- `WATCH`
+- `PROMOTE_TO_V1_RESEARCH`
+- `PROJECT_EVIDENCE_RECONCILIATION`
+
+Important:
+- `WATCH` is not a fifth TECH-RADAR-01 state.
+- `PROMOTE_TO_V1_RESEARCH` creates a future bounded research obligation only.
+- Admission cannot create TRIAL / ADOPT / IMPLEMENT / PRODUCTION / PHYSICAL authority.
+- Human-supplied route is validated; the core does not automatically choose an admission route.
+
+### TECH-RADAR-05 — continuous external research feed reservation
+
+The Physical AI project already defines TECH-RADAR-05 as the future upstream external sensing layer:
+
+`public external world`
+→ discover candidate signals
+→ collect provenance
+→ deduplicate / normalize
+→ draft Observation Packet
+→ TECH-RADAR-04 admission
+
+Current operating mode remains:
+
+`ChatGPT / human external research`
+→ bounded manually reviewed Observation Packet
+→ TECH-RADAR-04
+
+Full repository-native collector/scheduler remains a separately governed implementation decision.
+
+## 3. Anti-bloat rule
+
+The Physical AI repository stores compressed project knowledge and decisions, not raw news streams.
+
+Preserve:
+- one stable knowledge theme per Observation Packet;
+- bounded sources and claims;
+- material updates rather than headline-shaped files;
+- no screenshot dumps;
+- no long chat transcript commits;
+- no new Python module merely because a new technology appears;
+- no popularity/virality score as decision authority.
+
+Principle:
+
+> New knowledge does not imply new code.
+
+## 4. News Radar vs Technology Radar responsibilities
+
+### News / Systemic-Risk Radar owns
+- discovery;
+- broad current-affairs context;
+- global event clustering;
+- source quality;
+- trend/change detection;
+- user-facing briefing;
+- systemic-risk mapping;
+- P0/P1/P2 attention priority.
+
+### Physical AI Technology Radar owns
+- Physical AI engineering evidence;
+- candidate/decision governance;
+- admission packet semantics;
+- architecture context;
+- research/adopt/implementation authority;
+- project evidence memory.
+
+## 5. Handoff trigger
+
+A Physical AI news item should be handed to TECH-RADAR-04 when it contains a material project-relevant signal, for example:
+- architecture implication;
+- new capability family;
+- important safety/degraded-runtime lesson;
+- meaningful platform/ecosystem move;
+- candidate technology worth bounded research;
+- new evidence affecting an existing radar item;
+- evidence requiring project reconciliation.
+
+Routine Physical AI news can remain in the news layer without creating an Observation Packet.
+
+## 6. No duplicate authority
+
+The general News Radar may recommend:
+- attention;
+- further verification;
+- handoff to TECH-RADAR-04.
+
+It may not directly declare:
+- TECH-RADAR-01 TRIAL;
+- ADOPT;
+- IMPLEMENT;
+- PRODUCTION;
+- PHYSICAL authorization.
+
+That authority remains in the Physical AI project's existing governance.
+
+## 7. Future automation boundary
+
+Phase 3R can make active discovery, dedup, clustering and handoff suggestions smarter.
+
+It should not silently implement a repository-native TECH-RADAR-05 collector if that would widen the Physical AI project's currently reserved/deferred automation scope.
+
+Any future automatic Observation Packet drafting or automatic routing requires an explicit governance gate in the Physical AI project.


### PR DESCRIPTION
Closes #20

## What this captures

- Existing user-facing news-radar behavior
- P0/P1/P2 attention semantics
- Evidence · Behavior · Systems backend reasoning
- Multi-risk resonance baseline
- Front-end compression rules
- Physical AI Radar as part of the same intelligence product
- Exact integration boundary with the existing Physical AI Technology Radar

## Fresh-read Physical AI distinctions preserved

- TECH-RADAR-01 states: ASSESS / TRIAL / ADOPT / HOLD
- TECH-RADAR-04 admission routes:
  REJECT / DEFER / WATCH / PROMOTE_TO_V1_RESEARCH / PROJECT_EVIDENCE_RECONCILIATION
- TECH-RADAR-05: continuous external research feed architecture reservation
- Current Physical AI intake remains ChatGPT/human external research -> bounded Observation Packet -> TECH-RADAR-04
- WATCH is not a TECH-RADAR-01 state
- discovery/news cannot grant engineering/physical authority

## Reconciliation

If the original news-radar Markdown/spec is later supplied, it will be reconciled against this baseline rather than replacing working behavior silently.

No private operational state is added.