### PR TITLE
Phase 3R-01: source registry and evidence persistence v0.1

### DIFF
--- a/docs/SOURCE-EVIDENCE-PERSISTENCE.md
+++ b/docs/SOURCE-EVIDENCE-PERSISTENCE.md
@@ -1,0 +1,161 @@
+# Source Registry & Evidence Persistence — Phase 3R-01 v0.1
+
+## Purpose
+
+V0.3 already defines strong source/evidence judgment rules. R1 makes those rules durable.
+
+This phase does **not** decide which news is important and does not assign a universal source score.
+
+It persists:
+- who the source is;
+- what role it played for a specific claim;
+- whether the system actually read the material;
+- whether several reports are independent or derivative;
+- how a source has performed in a specific domain × claim type over time.
+
+## 1. Source Registry
+
+A source record captures durable publisher/source identity:
+
+- source class;
+- operating roles;
+- canonical origin;
+- ownership group when known;
+- domain strengths;
+- default access status.
+
+This is source identity, not a fact-confidence decision.
+
+## 2. Source Observation
+
+Independence is claim/event specific.
+
+A Source Observation therefore records:
+- claim_ref;
+- source_id;
+- publication/retrieval time;
+- access state;
+- role in this claim;
+- evidence type;
+- lineage relation;
+- independence group;
+- anonymous-origin group;
+- full-text verification state;
+- primary-material access.
+
+This prevents a publisher-level registry from pretending that every Reuters/AP/company/official item has the same evidentiary structure.
+
+## 3. Access Failure
+
+Canonical access states:
+- full_access
+- partial
+- paywall
+- robots_blocked
+- unavailable
+- metadata_only
+- unknown
+
+Hard rule:
+
+> If full text was not actually accessed and verified, the state must not imply full-text verification.
+
+The runtime may still use metadata/summary/discovery value, but it must disclose the limitation and reduce downstream confidence where relevant.
+
+## 4. Source lineage
+
+Lineage relations:
+- original
+- independent
+- repost
+- syndication
+- shared_press_release
+- shared_anonymous_origin
+- unknown
+
+The same claim repeated by multiple publishers only increases independent evidence when the underlying evidence origin is genuinely independent.
+
+Example:
+
+`Original wire report → portal repost → translated repost`
+
+may be 3 publishers but still 1 independence group.
+
+## 5. Source Concentration Gate
+
+R1 outputs one of:
+- UNKNOWN
+- SINGLE_ORIGIN
+- CONCENTRATED
+- DIVERSE
+
+It does not create a new risk/priority taxonomy.
+
+### SINGLE_ORIGIN
+All observed reports trace to one known evidence-origin group.
+
+### CONCENTRATED
+At least one known origin exists, but unresolved lineage prevents a diversity claim.
+
+### DIVERSE
+At least two known independence groups exist.
+
+### UNKNOWN
+Lineage is insufficient to establish independence.
+
+Search-result count is never evidence count.
+
+## 6. Source Reputation Ledger
+
+Reputation is explicitly:
+
+`source × domain × claim_type × time`
+
+Not:
+
+`source = 87/100 forever`
+
+Tracked dimensions may include:
+- original reporting ratio;
+- later-confirmed ratio;
+- correction frequency;
+- anonymous-source dependence;
+- headline exaggeration;
+- battlefield-claim accuracy;
+- PR-copy tendency;
+- median lead time;
+- directional/systematic error notes.
+
+Metrics may be null when not applicable or insufficiently sampled.
+
+No `global_score` field exists.
+
+## 7. Claim Grade vs Risk Variable namespace
+
+Use:
+- Claim Grade A-D
+- Risk Variable A-D
+
+Never use bare A/B/C/D where the meaning could be ambiguous.
+
+## 8. File-backed reference store
+
+`SourceStateStore` provides deterministic local persistence primitives for:
+- source records;
+- reputation records;
+- claim-level source observations.
+
+This is a reference implementation, not a crawler or production database.
+
+It deliberately does not:
+- crawl the web;
+- choose P0/P1/P2/P3;
+- automatically route Physical AI;
+- assign fact confidence;
+- change risk state.
+
+## 9. Phase boundary
+
+R1 establishes provenance memory.
+
+R2 will build Event Store / Claim Store and use these records as evidence lineage inputs.

--- a/examples/synthetic/source-concentration-assessment.json
+++ b/examples/synthetic/source-concentration-assessment.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "0.1.0",
+  "assessment_id": "sca-synthetic-001",
+  "claim_ref": "claim-synthetic-001",
+  "observation_ids": [
+    "sob-synthetic-001"
+  ],
+  "unique_source_count": 1,
+  "known_independence_group_count": 1,
+  "unknown_lineage_count": 0,
+  "derivative_observation_count": 0,
+  "access_limited_count": 0,
+  "state": "SINGLE_ORIGIN",
+  "single_source_bias": true,
+  "reasons": [
+    "all observations trace to one known independence group"
+  ],
+  "as_of": "2026-08-31T00:10:00Z",
+  "sensitivity": "public"
+}

--- a/examples/synthetic/source-observation.json
+++ b/examples/synthetic/source-observation.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "0.1.0",
+  "observation_id": "sob-synthetic-001",
+  "source_id": "src-synthetic-wire",
+  "claim_ref": "claim-synthetic-001",
+  "published_at": "2026-08-31T00:00:00Z",
+  "retrieved_at": "2026-08-31T00:05:00Z",
+  "access_status": "full_access",
+  "access_limit_note": null,
+  "source_role": "original_report",
+  "evidence_type": "interview",
+  "lineage": {
+    "relation": "original",
+    "origin_observation_id": null,
+    "independence_group_id": "ind-synthetic-origin-001",
+    "shared_origin_note": null
+  },
+  "anonymous_source": {
+    "present": false,
+    "origin_group_id": null
+  },
+  "provenance": {
+    "full_text_verified": true,
+    "primary_material_accessed": false,
+    "source_locator": "synthetic-section"
+  },
+  "sensitivity": "public"
+}

--- a/examples/synthetic/source-registry-record.json
+++ b/examples/synthetic/source-registry-record.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "0.1.0",
+  "source_id": "src-synthetic-wire",
+  "display_name": "Synthetic Wire Service",
+  "source_class": "global_media",
+  "roles": [
+    "discovery",
+    "original_reporting"
+  ],
+  "canonical_origin": {
+    "publisher": "Synthetic Wire Service",
+    "domain": "synthetic.example",
+    "uri": "https://synthetic.example/"
+  },
+  "ownership_group": null,
+  "domain_strengths": [
+    "diplomacy",
+    "financial_markets"
+  ],
+  "default_access_status": "full_access",
+  "notes": "Synthetic fixture only; not a real source reputation assertion.",
+  "updated_at": "2026-08-31T00:00:00Z",
+  "sensitivity": "public"
+}

--- a/examples/synthetic/source-reputation-record.json
+++ b/examples/synthetic/source-reputation-record.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "0.1.0",
+  "reputation_id": "rep-synthetic-wire-diplomacy-behavior",
+  "source_id": "src-synthetic-wire",
+  "domain": "diplomacy",
+  "claim_type": "behavior",
+  "sample_count": 20,
+  "metrics": {
+    "original_reporting_ratio": 0.8,
+    "later_confirmed_ratio": 0.75,
+    "correction_frequency": 0.05,
+    "anonymous_source_dependence": 0.4,
+    "headline_exaggeration": 0.1,
+    "battlefield_claim_accuracy": null,
+    "pr_copy_tendency": 0.05,
+    "median_lead_time_hours": 6
+  },
+  "directional_error_notes": [
+    "Synthetic example only."
+  ],
+  "limitations": [
+    "Not a real-world source assessment."
+  ],
+  "updated_at": "2026-08-31T00:00:00Z",
+  "sensitivity": "public"
+}

--- a/schemas/source-concentration-assessment.schema.json
+++ b/schemas/source-concentration-assessment.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/source-concentration-assessment.schema.json",
+  "title": "Source Concentration Assessment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "assessment_id",
+    "claim_ref",
+    "observation_ids",
+    "unique_source_count",
+    "known_independence_group_count",
+    "unknown_lineage_count",
+    "derivative_observation_count",
+    "access_limited_count",
+    "state",
+    "single_source_bias",
+    "reasons",
+    "as_of",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "assessment_id": {
+      "type": "string",
+      "pattern": "^sca-[A-Za-z0-9._-]+$"
+    },
+    "claim_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "observation_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^sob-[A-Za-z0-9._-]+$"
+      }
+    },
+    "unique_source_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "known_independence_group_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "unknown_lineage_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "derivative_observation_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "access_limited_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "state": {
+      "enum": [
+        "UNKNOWN",
+        "SINGLE_ORIGIN",
+        "CONCENTRATED",
+        "DIVERSE"
+      ]
+    },
+    "single_source_bias": {
+      "type": "boolean"
+    },
+    "reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "as_of": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/source-observation.schema.json
+++ b/schemas/source-observation.schema.json
@@ -1,0 +1,261 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/source-observation.schema.json",
+  "title": "Source Observation / Claim Provenance Hook",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "observation_id",
+    "source_id",
+    "claim_ref",
+    "published_at",
+    "retrieved_at",
+    "access_status",
+    "source_role",
+    "evidence_type",
+    "lineage",
+    "anonymous_source",
+    "provenance",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "observation_id": {
+      "type": "string",
+      "pattern": "^sob-[A-Za-z0-9._-]+$"
+    },
+    "source_id": {
+      "type": "string",
+      "pattern": "^src-[A-Za-z0-9._-]+$"
+    },
+    "claim_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Opaque future Claim Store reference."
+    },
+    "published_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "retrieved_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "access_status": {
+      "enum": [
+        "full_access",
+        "partial",
+        "paywall",
+        "robots_blocked",
+        "unavailable",
+        "metadata_only",
+        "unknown"
+      ]
+    },
+    "access_limit_note": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "source_role": {
+      "enum": [
+        "original_report",
+        "original_document",
+        "official_statement",
+        "derivative_report",
+        "aggregated_result",
+        "technical_primary",
+        "field_evidence",
+        "data_observation",
+        "narrative_signal",
+        "other"
+      ]
+    },
+    "evidence_type": {
+      "enum": [
+        "document",
+        "database",
+        "interview",
+        "anonymous_interview",
+        "video",
+        "image",
+        "satellite",
+        "geolocation",
+        "hardware_evidence",
+        "market_data",
+        "shipping_data",
+        "sensor_data",
+        "technical_paper",
+        "source_code",
+        "official_statement",
+        "social_post",
+        "other"
+      ]
+    },
+    "lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "relation",
+        "origin_observation_id",
+        "independence_group_id"
+      ],
+      "properties": {
+        "relation": {
+          "enum": [
+            "original",
+            "independent",
+            "repost",
+            "syndication",
+            "shared_press_release",
+            "shared_anonymous_origin",
+            "unknown"
+          ]
+        },
+        "origin_observation_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "independence_group_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "shared_origin_note": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "anonymous_source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "present",
+        "origin_group_id"
+      ],
+      "properties": {
+        "present": {
+          "type": "boolean"
+        },
+        "origin_group_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Group shared anonymous-origin claims where known."
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "full_text_verified",
+        "primary_material_accessed",
+        "source_locator"
+      ],
+      "properties": {
+        "full_text_verified": {
+          "type": "boolean"
+        },
+        "primary_material_accessed": {
+          "type": "boolean"
+        },
+        "source_locator": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "lineage": {
+            "properties": {
+              "relation": {
+                "enum": [
+                  "repost",
+                  "syndication",
+                  "shared_press_release",
+                  "shared_anonymous_origin"
+                ]
+              }
+            },
+            "required": [
+              "relation"
+            ]
+          }
+        },
+        "required": [
+          "lineage"
+        ]
+      },
+      "then": {
+        "properties": {
+          "lineage": {
+            "properties": {
+              "origin_observation_id": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "origin_observation_id"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "provenance": {
+            "properties": {
+              "full_text_verified": {
+                "const": true
+              }
+            },
+            "required": [
+              "full_text_verified"
+            ]
+          }
+        },
+        "required": [
+          "provenance"
+        ]
+      },
+      "then": {
+        "properties": {
+          "access_status": {
+            "const": "full_access"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/source-registry-record.schema.json
+++ b/schemas/source-registry-record.schema.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/source-registry-record.schema.json",
+  "title": "Source Registry Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "source_id",
+    "display_name",
+    "source_class",
+    "roles",
+    "canonical_origin",
+    "domain_strengths",
+    "default_access_status",
+    "updated_at",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "source_id": {
+      "type": "string",
+      "pattern": "^src-[A-Za-z0-9._-]+$"
+    },
+    "display_name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "source_class": {
+      "enum": [
+        "global_media",
+        "specialist_media",
+        "government",
+        "regulator",
+        "company",
+        "academic",
+        "technical_primary",
+        "military",
+        "osint",
+        "disaster_data",
+        "market_data",
+        "social",
+        "aggregator",
+        "other"
+      ]
+    },
+    "roles": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "discovery",
+          "original_reporting",
+          "official_record",
+          "official_statement",
+          "technical_primary",
+          "field_evidence",
+          "data_provider",
+          "market_context",
+          "narrative_monitoring",
+          "aggregator"
+        ]
+      }
+    },
+    "canonical_origin": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "publisher",
+        "domain"
+      ],
+      "properties": {
+        "publisher": {
+          "type": "string",
+          "minLength": 1
+        },
+        "domain": {
+          "type": "string",
+          "minLength": 1
+        },
+        "uri": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        }
+      }
+    },
+    "ownership_group": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "domain_strengths": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "china_policy",
+          "macro",
+          "financial_markets",
+          "industry",
+          "technology",
+          "diplomacy",
+          "military",
+          "taiwan_strait",
+          "south_china_sea",
+          "sanctions_export_controls",
+          "corporate",
+          "disaster",
+          "physical_ai",
+          "war_unmanned_systems",
+          "energy",
+          "shipping",
+          "supply_chain",
+          "global_risk",
+          "other"
+        ]
+      }
+    },
+    "default_access_status": {
+      "enum": [
+        "full_access",
+        "partial",
+        "paywall",
+        "robots_blocked",
+        "unavailable",
+        "metadata_only",
+        "unknown"
+      ]
+    },
+    "notes": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/source-reputation-record.schema.json
+++ b/schemas/source-reputation-record.schema.json
@@ -1,0 +1,181 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/source-reputation-record.schema.json",
+  "title": "Source Reputation Ledger Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "reputation_id",
+    "source_id",
+    "domain",
+    "claim_type",
+    "sample_count",
+    "metrics",
+    "directional_error_notes",
+    "updated_at",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "reputation_id": {
+      "type": "string",
+      "pattern": "^rep-[A-Za-z0-9._-]+$"
+    },
+    "source_id": {
+      "type": "string",
+      "pattern": "^src-[A-Za-z0-9._-]+$"
+    },
+    "domain": {
+      "enum": [
+        "china_policy",
+        "macro",
+        "financial_markets",
+        "industry",
+        "technology",
+        "diplomacy",
+        "military",
+        "taiwan_strait",
+        "south_china_sea",
+        "sanctions_export_controls",
+        "corporate",
+        "disaster",
+        "physical_ai",
+        "war_unmanned_systems",
+        "energy",
+        "shipping",
+        "supply_chain",
+        "global_risk",
+        "other"
+      ]
+    },
+    "claim_type": {
+      "enum": [
+        "existence",
+        "time",
+        "quantity",
+        "identity",
+        "behavior",
+        "legal_status",
+        "causal",
+        "motive",
+        "intent",
+        "prediction",
+        "battle_result",
+        "technical_performance",
+        "commercial_scale",
+        "other"
+      ]
+    },
+    "sample_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "original_reporting_ratio",
+        "later_confirmed_ratio",
+        "correction_frequency",
+        "anonymous_source_dependence",
+        "headline_exaggeration",
+        "battlefield_claim_accuracy",
+        "pr_copy_tendency",
+        "median_lead_time_hours"
+      ],
+      "properties": {
+        "original_reporting_ratio": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1
+        },
+        "later_confirmed_ratio": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1
+        },
+        "correction_frequency": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1
+        },
+        "anonymous_source_dependence": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1
+        },
+        "headline_exaggeration": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1
+        },
+        "battlefield_claim_accuracy": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1
+        },
+        "pr_copy_tendency": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1
+        },
+        "median_lead_time_hours": {
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      }
+    },
+    "directional_error_notes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/scripts/validate_schemas.py
+++ b/scripts/validate_schemas.py
@@ -23,6 +23,10 @@ PAIRS = {
     "water_verification_assessment": ("schemas/water-verification-assessment.schema.json", "examples/synthetic/water-verification-assessment.json"),
     "energy_resilience_audit": ("schemas/energy-resilience-audit.schema.json", "examples/synthetic/energy-resilience-audit.json"),
     "energy_verification_assessment": ("schemas/energy-verification-assessment.schema.json", "examples/synthetic/energy-verification-assessment.json"),
+    "source_registry_record": ("schemas/source-registry-record.schema.json", "examples/synthetic/source-registry-record.json"),
+    "source_observation": ("schemas/source-observation.schema.json", "examples/synthetic/source-observation.json"),
+    "source_reputation_record": ("schemas/source-reputation-record.schema.json", "examples/synthetic/source-reputation-record.json"),
+    "source_concentration_assessment": ("schemas/source-concentration-assessment.schema.json", "examples/synthetic/source-concentration-assessment.json"),
 }
 
 def load(path):
@@ -97,6 +101,24 @@ def semantic_errors(name, obj):
         if outage["status"] == "pass":
             if not outage.get("duration_hours") or outage["duration_hours"] <= 0:
                 errors.append("passed outage test requires positive duration_hours")
+    elif name == "source_observation":
+        if obj["provenance"]["full_text_verified"] and obj["access_status"] != "full_access":
+            errors.append("full_text_verified requires full_access")
+        if obj["lineage"]["relation"] in {"repost", "syndication", "shared_press_release", "shared_anonymous_origin"}:
+            if not obj["lineage"].get("origin_observation_id"):
+                errors.append("derivative lineage requires origin_observation_id")
+    elif name == "source_concentration_assessment":
+        if obj["known_independence_group_count"] > obj["unique_source_count"]:
+            errors.append("known independence groups cannot exceed unique sources")
+        if obj["derivative_observation_count"] > len(obj["observation_ids"]):
+            errors.append("derivative count cannot exceed observation count")
+        if obj["state"] == "SINGLE_ORIGIN":
+            if obj["known_independence_group_count"] != 1 or obj["unknown_lineage_count"] != 0:
+                errors.append("SINGLE_ORIGIN requires exactly one known group and no unknown lineage")
+            if not obj["single_source_bias"]:
+                errors.append("SINGLE_ORIGIN must set single_source_bias=true")
+        if obj["state"] == "DIVERSE" and obj["known_independence_group_count"] < 2:
+            errors.append("DIVERSE requires at least two known independence groups")
     return errors
 
 def main():

--- a/src/psrro/__init__.py
+++ b/src/psrro/__init__.py
@@ -1,3 +1,9 @@
+from .intelligence_sources import (
+    SourceStateStore,
+    access_disclosure_required,
+    assess_source_concentration,
+    can_claim_full_text_verified,
+)
 from .energy import assess_energy_verification
 from .water import assess_water_verification
 from .preparedness import preparedness_snapshot
@@ -11,6 +17,10 @@ from .quantification import (
 )
 
 __all__ = [
+    "SourceStateStore",
+    "access_disclosure_required",
+    "assess_source_concentration",
+    "can_claim_full_text_verified",
     "assess_energy_verification",
     "assess_water_verification",
     "preparedness_snapshot",

--- a/src/psrro/intelligence_sources.py
+++ b/src/psrro/intelligence_sources.py
@@ -1,0 +1,172 @@
+"""Phase 3R-01 source/evidence persistence primitives.
+
+The point of this module is not to decide which source is "good". It persists
+identity, lineage and access state so later claim/judgment logic can be audited.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Mapping, Sequence
+
+DERIVATIVE_RELATIONS = {
+    "repost",
+    "syndication",
+    "shared_press_release",
+    "shared_anonymous_origin",
+}
+ACCESS_LIMITED = {
+    "partial",
+    "paywall",
+    "robots_blocked",
+    "unavailable",
+    "metadata_only",
+    "unknown",
+}
+
+
+def _write_json(path: Path, obj: Mapping) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(obj, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    path.write_text(payload, encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class SourceStateStore:
+    """Minimal file-backed store for durable source intelligence state."""
+
+    def __init__(self, root: str | Path):
+        self.root = Path(root)
+
+    def upsert_source(self, record: Mapping) -> Path:
+        path = self.root / "sources" / f"{record['source_id']}.json"
+        _write_json(path, record)
+        return path
+
+    def get_source(self, source_id: str) -> dict:
+        return _load_json(self.root / "sources" / f"{source_id}.json")
+
+    def upsert_reputation(self, record: Mapping) -> Path:
+        safe_domain = record["domain"].replace("/", "_")
+        safe_claim = record["claim_type"].replace("/", "_")
+        path = (
+            self.root
+            / "reputation"
+            / record["source_id"]
+            / f"{safe_domain}__{safe_claim}.json"
+        )
+        _write_json(path, record)
+        return path
+
+    def get_reputation(self, source_id: str, domain: str, claim_type: str) -> dict:
+        return _load_json(
+            self.root
+            / "reputation"
+            / source_id
+            / f"{domain.replace('/', '_')}__{claim_type.replace('/', '_')}.json"
+        )
+
+    def put_observation(self, record: Mapping) -> Path:
+        path = self.root / "observations" / f"{record['observation_id']}.json"
+        _write_json(path, record)
+        return path
+
+    def get_observation(self, observation_id: str) -> dict:
+        return _load_json(self.root / "observations" / f"{observation_id}.json")
+
+
+def assess_source_concentration(
+    observations: Sequence[Mapping],
+    *,
+    assessment_id: str = "sca-derived",
+    claim_ref: str | None = None,
+    as_of: str = "1970-01-01T00:00:00Z",
+    sensitivity: str = "public",
+) -> dict:
+    """Assess independence without converting search-result count into evidence count."""
+
+    if claim_ref is None:
+        claim_refs = {obs.get("claim_ref") for obs in observations if obs.get("claim_ref")}
+        if len(claim_refs) == 1:
+            claim_ref = next(iter(claim_refs))
+        elif not claim_refs:
+            claim_ref = "claim-unknown"
+        else:
+            raise ValueError("observations must refer to one claim_ref")
+
+    unique_sources = {obs["source_id"] for obs in observations}
+    known_groups = {
+        obs.get("lineage", {}).get("independence_group_id")
+        for obs in observations
+        if obs.get("lineage", {}).get("independence_group_id")
+    }
+    unknown_lineage = sum(
+        not bool(obs.get("lineage", {}).get("independence_group_id"))
+        or obs.get("lineage", {}).get("relation") == "unknown"
+        for obs in observations
+    )
+    derivative_count = sum(
+        obs.get("lineage", {}).get("relation") in DERIVATIVE_RELATIONS
+        for obs in observations
+    )
+    access_limited_count = sum(
+        obs.get("access_status") in ACCESS_LIMITED for obs in observations
+    )
+
+    reasons: list[str] = []
+
+    if not observations or not known_groups:
+        state = "UNKNOWN"
+        single_source_bias = False
+        reasons.append("independence lineage is insufficient to establish source diversity")
+    elif len(known_groups) == 1 and unknown_lineage == 0:
+        state = "SINGLE_ORIGIN"
+        single_source_bias = True
+        reasons.append("all observations trace to one known independence group")
+    elif len(known_groups) == 1:
+        state = "CONCENTRATED"
+        single_source_bias = False
+        reasons.append("one known origin plus unresolved lineage")
+    else:
+        state = "DIVERSE"
+        single_source_bias = False
+        reasons.append("at least two known independent evidence groups")
+
+    if derivative_count:
+        reasons.append(f"{derivative_count} derivative observations do not add independent evidence")
+    if access_limited_count:
+        reasons.append(f"{access_limited_count} observations have limited/unknown access")
+
+    return {
+        "schema_version": "0.1.0",
+        "assessment_id": assessment_id,
+        "claim_ref": claim_ref,
+        "observation_ids": [obs["observation_id"] for obs in observations],
+        "unique_source_count": len(unique_sources),
+        "known_independence_group_count": len(known_groups),
+        "unknown_lineage_count": unknown_lineage,
+        "derivative_observation_count": derivative_count,
+        "access_limited_count": access_limited_count,
+        "state": state,
+        "single_source_bias": single_source_bias,
+        "reasons": reasons,
+        "as_of": as_of,
+        "sensitivity": sensitivity,
+    }
+
+
+def access_disclosure_required(observation: Mapping) -> bool:
+    """True when the observation must disclose an access limitation."""
+    return observation.get("access_status") in ACCESS_LIMITED
+
+
+def can_claim_full_text_verified(observation: Mapping) -> bool:
+    """Fail closed: only full_access + explicit verification supports this claim."""
+    return (
+        observation.get("access_status") == "full_access"
+        and observation.get("provenance", {}).get("full_text_verified") is True
+    )

--- a/src/psrro/intelligence_sources.py
+++ b/src/psrro/intelligence_sources.py
@@ -7,6 +7,7 @@ identity, lineage and access state so later claim/judgment logic can be audited.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Mapping, Sequence
 
@@ -24,6 +25,13 @@ ACCESS_LIMITED = {
     "metadata_only",
     "unknown",
 }
+SAFE_COMPONENT = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _safe_component(value: str, label: str) -> str:
+    if not SAFE_COMPONENT.fullmatch(value) or value in {".", ".."}:
+        raise ValueError(f"unsafe {label}: {value!r}")
+    return value
 
 
 def _write_json(path: Path, obj: Mapping) -> None:
@@ -43,39 +51,44 @@ class SourceStateStore:
         self.root = Path(root)
 
     def upsert_source(self, record: Mapping) -> Path:
-        path = self.root / "sources" / f"{record['source_id']}.json"
+        source_id = _safe_component(str(record["source_id"]), "source_id")
+        path = self.root / "sources" / f"{source_id}.json"
         _write_json(path, record)
         return path
 
     def get_source(self, source_id: str) -> dict:
+        source_id = _safe_component(source_id, "source_id")
         return _load_json(self.root / "sources" / f"{source_id}.json")
 
     def upsert_reputation(self, record: Mapping) -> Path:
-        safe_domain = record["domain"].replace("/", "_")
-        safe_claim = record["claim_type"].replace("/", "_")
+        source_id = _safe_component(str(record["source_id"]), "source_id")
+        safe_domain = _safe_component(str(record["domain"]), "domain")
+        safe_claim = _safe_component(str(record["claim_type"]), "claim_type")
         path = (
             self.root
             / "reputation"
-            / record["source_id"]
+            / source_id
             / f"{safe_domain}__{safe_claim}.json"
         )
         _write_json(path, record)
         return path
 
     def get_reputation(self, source_id: str, domain: str, claim_type: str) -> dict:
+        source_id = _safe_component(source_id, "source_id")
+        domain = _safe_component(domain, "domain")
+        claim_type = _safe_component(claim_type, "claim_type")
         return _load_json(
-            self.root
-            / "reputation"
-            / source_id
-            / f"{domain.replace('/', '_')}__{claim_type.replace('/', '_')}.json"
+            self.root / "reputation" / source_id / f"{domain}__{claim_type}.json"
         )
 
     def put_observation(self, record: Mapping) -> Path:
-        path = self.root / "observations" / f"{record['observation_id']}.json"
+        observation_id = _safe_component(str(record["observation_id"]), "observation_id")
+        path = self.root / "observations" / f"{observation_id}.json"
         _write_json(path, record)
         return path
 
     def get_observation(self, observation_id: str) -> dict:
+        observation_id = _safe_component(observation_id, "observation_id")
         return _load_json(self.root / "observations" / f"{observation_id}.json")
 
 
@@ -89,14 +102,16 @@ def assess_source_concentration(
 ) -> dict:
     """Assess independence without converting search-result count into evidence count."""
 
+    claim_refs = {obs.get("claim_ref") for obs in observations if obs.get("claim_ref")}
     if claim_ref is None:
-        claim_refs = {obs.get("claim_ref") for obs in observations if obs.get("claim_ref")}
         if len(claim_refs) == 1:
             claim_ref = next(iter(claim_refs))
         elif not claim_refs:
             claim_ref = "claim-unknown"
         else:
             raise ValueError("observations must refer to one claim_ref")
+    elif claim_refs and claim_refs != {claim_ref}:
+        raise ValueError("observations must match the requested claim_ref")
 
     unique_sources = {obs["source_id"] for obs in observations}
     known_groups = {
@@ -145,7 +160,7 @@ def assess_source_concentration(
         "schema_version": "0.1.0",
         "assessment_id": assessment_id,
         "claim_ref": claim_ref,
-        "observation_ids": [obs["observation_id"] for obs in observations],
+        "observation_ids": sorted(obs["observation_id"] for obs in observations),
         "unique_source_count": len(unique_sources),
         "known_independence_group_count": len(known_groups),
         "unknown_lineage_count": unknown_lineage,

--- a/tests/test_intelligence_sources.py
+++ b/tests/test_intelligence_sources.py
@@ -79,6 +79,22 @@ class SourceConcentrationTests(unittest.TestCase):
         self.assertEqual(result["state"], "UNKNOWN")
         self.assertEqual(result["known_independence_group_count"], 0)
 
+    def test_output_is_deterministic_across_input_order(self):
+        a = observation("sob-2", "src-b", group="group-b")
+        b = observation("sob-1", "src-a", group="group-a")
+        left = assess_source_concentration([a, b])
+        right = assess_source_concentration([b, a])
+        self.assertEqual(left["observation_ids"], right["observation_ids"])
+        self.assertEqual(left["state"], right["state"])
+
+    def test_explicit_claim_ref_rejects_mixed_claims(self):
+        rows = [
+            observation("sob-1", "src-a", claim_ref="claim-a"),
+            observation("sob-2", "src-b", claim_ref="claim-b", group="group-b"),
+        ]
+        with self.assertRaises(ValueError):
+            assess_source_concentration(rows, claim_ref="claim-a")
+
     def test_mixed_known_and_unknown_is_concentrated_not_diverse(self):
         rows = [
             observation("sob-1", "src-a", group="group-a"),
@@ -106,6 +122,16 @@ class AccessTests(unittest.TestCase):
 
 
 class StoreTests(unittest.TestCase):
+    def test_unsafe_path_component_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = SourceStateStore(tmp)
+            with self.assertRaises(ValueError):
+                store.upsert_source({
+                    "source_id": "../escape",
+                    "display_name": "Bad",
+                    "source_class": "other",
+                })
+
     def test_file_backed_store_round_trip(self):
         with tempfile.TemporaryDirectory() as tmp:
             store = SourceStateStore(tmp)

--- a/tests/test_intelligence_sources.py
+++ b/tests/test_intelligence_sources.py
@@ -1,0 +1,138 @@
+import tempfile
+import unittest
+
+from src.psrro.intelligence_sources import (
+    SourceStateStore,
+    access_disclosure_required,
+    assess_source_concentration,
+    can_claim_full_text_verified,
+)
+
+
+def observation(
+    oid,
+    sid,
+    *,
+    claim_ref="claim-synthetic",
+    relation="independent",
+    group="group-a",
+    access="full_access",
+    full_text=True,
+    origin=None,
+):
+    return {
+        "schema_version": "0.1.0",
+        "observation_id": oid,
+        "source_id": sid,
+        "claim_ref": claim_ref,
+        "published_at": "2026-08-31T00:00:00Z",
+        "retrieved_at": "2026-08-31T00:05:00Z",
+        "access_status": access,
+        "access_limit_note": None,
+        "source_role": "original_report",
+        "evidence_type": "document",
+        "lineage": {
+            "relation": relation,
+            "origin_observation_id": origin,
+            "independence_group_id": group,
+            "shared_origin_note": None,
+        },
+        "anonymous_source": {"present": False, "origin_group_id": None},
+        "provenance": {
+            "full_text_verified": full_text,
+            "primary_material_accessed": True,
+            "source_locator": "synthetic",
+        },
+        "sensitivity": "public",
+    }
+
+
+class SourceConcentrationTests(unittest.TestCase):
+    def test_two_reposts_of_one_origin_are_single_origin(self):
+        rows = [
+            observation("sob-1", "src-origin", relation="original", group="origin-1"),
+            observation("sob-2", "src-repost-a", relation="repost", group="origin-1", origin="sob-1"),
+            observation("sob-3", "src-repost-b", relation="syndication", group="origin-1", origin="sob-1"),
+        ]
+        result = assess_source_concentration(rows)
+        self.assertEqual(result["unique_source_count"], 3)
+        self.assertEqual(result["known_independence_group_count"], 1)
+        self.assertEqual(result["derivative_observation_count"], 2)
+        self.assertEqual(result["state"], "SINGLE_ORIGIN")
+        self.assertTrue(result["single_source_bias"])
+
+    def test_two_independent_groups_are_diverse(self):
+        rows = [
+            observation("sob-1", "src-a", group="group-a"),
+            observation("sob-2", "src-b", group="group-b"),
+        ]
+        result = assess_source_concentration(rows)
+        self.assertEqual(result["state"], "DIVERSE")
+        self.assertFalse(result["single_source_bias"])
+
+    def test_unknown_lineage_does_not_fake_independence(self):
+        rows = [
+            observation("sob-1", "src-a", relation="unknown", group=None),
+            observation("sob-2", "src-b", relation="unknown", group=None),
+        ]
+        result = assess_source_concentration(rows)
+        self.assertEqual(result["state"], "UNKNOWN")
+        self.assertEqual(result["known_independence_group_count"], 0)
+
+    def test_mixed_known_and_unknown_is_concentrated_not_diverse(self):
+        rows = [
+            observation("sob-1", "src-a", group="group-a"),
+            observation("sob-2", "src-b", relation="unknown", group=None),
+        ]
+        result = assess_source_concentration(rows)
+        self.assertEqual(result["state"], "CONCENTRATED")
+
+
+class AccessTests(unittest.TestCase):
+    def test_paywall_requires_disclosure(self):
+        row = observation("sob-1", "src-a", access="paywall", full_text=False)
+        self.assertTrue(access_disclosure_required(row))
+        self.assertFalse(can_claim_full_text_verified(row))
+
+    def test_metadata_only_cannot_claim_full_text(self):
+        row = observation("sob-1", "src-a", access="metadata_only", full_text=False)
+        self.assertTrue(access_disclosure_required(row))
+        self.assertFalse(can_claim_full_text_verified(row))
+
+    def test_full_access_plus_flag_can_claim_full_text(self):
+        row = observation("sob-1", "src-a", access="full_access", full_text=True)
+        self.assertFalse(access_disclosure_required(row))
+        self.assertTrue(can_claim_full_text_verified(row))
+
+
+class StoreTests(unittest.TestCase):
+    def test_file_backed_store_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = SourceStateStore(tmp)
+            source = {
+                "source_id": "src-synthetic",
+                "display_name": "Synthetic Source",
+                "source_class": "other",
+            }
+            reputation = {
+                "source_id": "src-synthetic",
+                "domain": "global_risk",
+                "claim_type": "causal",
+                "sample_count": 3,
+            }
+            obs = observation("sob-1", "src-synthetic")
+
+            store.upsert_source(source)
+            store.upsert_reputation(reputation)
+            store.put_observation(obs)
+
+            self.assertEqual(store.get_source("src-synthetic"), source)
+            self.assertEqual(
+                store.get_reputation("src-synthetic", "global_risk", "causal"),
+                reputation,
+            )
+            self.assertEqual(store.get_observation("sob-1"), obs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #24

## Implements

- Source Registry schema
- Claim-level Source Observation / provenance hook
- Source Reputation Ledger schema
- Source Concentration Assessment schema
- deterministic file-backed SourceStateStore reference implementation
- derivative/repost lineage handling
- Access Failure disclosure helpers
- source-concentration gate
- synthetic fixtures and tests
- unified schema validation

## Preserved V0.3 rules

- repost count != independent evidence count
- full-text verification cannot be claimed through paywall/metadata-only access
- reputation is source × domain × claim type, not one universal score
- low-reputation sources may still serve discovery/narrative roles
- source lineage is claim-specific
- Claim Grade A-D remains distinct from Risk Variable A-D

## Non-goals

No crawler, scheduler, P0 decision engine, TECH-RADAR auto-routing, or model-state update.

Only synthetic public-safe fixtures are included.
