### PR TITLE
Phase 3R-02: event and claim state v0.1

### DIFF
--- a/docs/EVENT-CLAIM-STATE.md
+++ b/docs/EVENT-CLAIM-STATE.md
@@ -1,0 +1,121 @@
+# Event / Claim State — Phase 3R-02 v0.1
+
+## Purpose
+
+R1 remembers where evidence came from.
+
+R2 remembers **what event/claim the system thought it was looking at**, how that state changed, and whether an update was materially new.
+
+It implements the V0.3 Candidate Event Pool / Event Cluster / Atomic Claim / Material Change / dynamic-number discipline without introducing automatic semantic extraction.
+
+## 1. Event compatibility
+
+The existing Phase 1 `Event` remains valid.
+
+Compatibility updates:
+- `intelligence_priority` now supports P0-P3.
+- P3 is stored/background and remains non-push by default.
+
+R2 adds `Event State Record` for stateful clustering/persistence.
+
+## 2. Event fingerprint
+
+V0.3 cluster basis:
+
+`Actor + Action + Object + Location + Time Window + Consequence`
+
+R2 stores an immutable first-seen canonical `fingerprint_basis` and SHA-256 fingerprint.
+
+Display title is deliberately excluded.
+
+Therefore:
+- headline rewrites do not create a new event;
+- canonical identity changes require explicit re-clustering rather than silently mutating one event.
+
+The fingerprint function normalizes case/whitespace and list order. Upstream semantic normalization is still required; this v0.1 function does not know that “US” and “United States” are synonyms.
+
+## 3. Claim Store
+
+Each atomic Claim stores:
+- V0.3 claim kind;
+- epistemic class;
+- statement;
+- **Claim Grade A-D**;
+- source-observation refs;
+- evidence refs;
+- status/supersession;
+- optional dynamic-value policy.
+
+Claim Grade A-D is epistemic confidence and must never be confused with Risk Variable A-D.
+
+## 4. Dynamic numbers
+
+Changing numbers such as casualties, missing people, strike counts, order values or financing values are stored as separate timestamped observations:
+
+`value + unit + as_of + recorded_at + source refs + Claim Grade`
+
+Old and new numbers are not overwritten into one timeless field.
+
+## 5. Claim-specific numeric materiality
+
+There is no global “10% means material” rule.
+
+A dynamic Claim may define:
+- none
+- any_change
+- absolute
+- relative
+- either absolute/relative
+
+This allows casualty counts, oil prices, order values and financing amounts to use different materiality logic.
+
+Relative change from a zero baseline fails closed unless an absolute threshold also exists.
+
+## 6. Material Change
+
+The detector ignores title/source-list noise and recognizes structural change through:
+- new event;
+- P-level change;
+- V0.3 material markers;
+- qualifying lifecycle change;
+- material Claim Grade change;
+- claim-specific numeric material change.
+
+Representable V0.3 transitions include:
+- threat → attack
+- declaration → budget
+- budget → procurement
+- procurement → delivery
+- demo → deployment
+- test → scaled production
+- shipping risk → actual suspension
+- expectation → real price transmission
+
+The detector does not invent these transitions from prose. Upstream analysis must supply the semantic marker.
+
+## 7. Evidence compatibility
+
+The Phase 1 Evidence schema now allows `target_type=claim`.
+
+This lets future Evidence Graph records attach directly to atomic Claims instead of forcing all evidence to point only at an Event/Edge/Scenario.
+
+## 8. File-backed state
+
+`EventClaimStateStore` persists:
+- events
+- claims
+- dynamic claim values
+- material-change assessments
+
+It is deterministic reference storage, not a production database or crawler.
+
+## 9. Phase boundary
+
+R2 establishes event/claim memory.
+
+R3 will add:
+- Costly Signal
+- Rhetoric–Action Gap
+- Narrative Gap
+- Counterevidence/falsification
+- Risk Variable / Edge / Coupling / Buffer / Scenario deltas

--- a/examples/synthetic/claim-record.json
+++ b/examples/synthetic/claim-record.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "0.1.0",
+  "claim_id": "clm-synthetic-r2-001",
+  "event_id": "evt-synthetic-r2-001",
+  "claim_kind": "quantity",
+  "epistemic_class": "fact",
+  "statement": "Synthetic quantity claim.",
+  "claim_grade": "C",
+  "grade_updated_at": "2026-08-31T01:00:00Z",
+  "status": "developing",
+  "source_observation_ids": [
+    "sob-synthetic-001"
+  ],
+  "evidence_ids": [],
+  "dynamic_value_policy": {
+    "value_type": "number",
+    "unit": "synthetic-units",
+    "materiality_rule": "absolute",
+    "absolute_delta": 10,
+    "relative_delta": null
+  },
+  "superseded_by_claim_id": null,
+  "last_updated": "2026-08-31T01:00:00Z",
+  "sensitivity": "public"
+}

--- a/examples/synthetic/claim-value-observation.json
+++ b/examples/synthetic/claim-value-observation.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "0.1.0",
+  "value_observation_id": "cvo-synthetic-r2-001",
+  "claim_id": "clm-synthetic-r2-001",
+  "value": 100,
+  "unit": "synthetic-units",
+  "as_of": "2026-08-31T00:30:00Z",
+  "recorded_at": "2026-08-31T01:00:00Z",
+  "claim_grade": "C",
+  "source_observation_ids": [
+    "sob-synthetic-001"
+  ],
+  "notes": "Synthetic dynamic value.",
+  "sensitivity": "public"
+}

--- a/examples/synthetic/event-state-record.json
+++ b/examples/synthetic/event-state-record.json
@@ -22,7 +22,7 @@
       "Operational change"
     ]
   },
-  "fingerprint": "4cfd8ce370c4d12bb393f6f55be60d35380c53f3d26cfe1f61c6571925747762",
+  "fingerprint": "cb04875bb8484e37279a31a4310aa13a019d2b2bc4e325cc23fd27c9ca250465",
   "first_seen": "2026-08-31T00:00:00Z",
   "last_updated": "2026-08-31T01:00:00Z",
   "intelligence_priority": "P3",

--- a/examples/synthetic/event-state-record.json
+++ b/examples/synthetic/event-state-record.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "0.1.0",
+  "event_id": "evt-synthetic-r2-001",
+  "display_title": "Synthetic event state",
+  "event_type": "synthetic_deployment",
+  "domain": "technology",
+  "fingerprint_basis": {
+    "actors": [
+      "Synthetic Actor"
+    ],
+    "actions": [
+      "Deploy"
+    ],
+    "objects": [
+      "Synthetic System"
+    ],
+    "locations": [
+      "Synthetic Region"
+    ],
+    "time_window_key": "2026-08-31",
+    "consequences": [
+      "Operational change"
+    ]
+  },
+  "fingerprint": "4cfd8ce370c4d12bb393f6f55be60d35380c53f3d26cfe1f61c6571925747762",
+  "first_seen": "2026-08-31T00:00:00Z",
+  "last_updated": "2026-08-31T01:00:00Z",
+  "intelligence_priority": "P3",
+  "lifecycle": "developing",
+  "claim_ids": [
+    "clm-synthetic-r2-001"
+  ],
+  "source_observation_ids": [
+    "sob-synthetic-001"
+  ],
+  "material_markers": [],
+  "notes": "Synthetic fixture only.",
+  "sensitivity": "public"
+}

--- a/examples/synthetic/material-change-assessment.json
+++ b/examples/synthetic/material-change-assessment.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "0.1.0",
+  "assessment_id": "mca-synthetic-r2-001",
+  "event_id": "evt-synthetic-r2-001",
+  "previous_state_ref": "snapshot-0",
+  "current_state_ref": "snapshot-1",
+  "material": true,
+  "change_types": [
+    "priority_change"
+  ],
+  "changed_claim_ids": [],
+  "numeric_change_refs": [],
+  "priority_from": "P3",
+  "priority_to": "P2",
+  "reasons": [
+    "priority changed P3->P2"
+  ],
+  "assessed_at": "2026-08-31T01:00:00Z",
+  "sensitivity": "public"
+}

--- a/schemas/claim-record.schema.json
+++ b/schemas/claim-record.schema.json
@@ -1,0 +1,201 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/claim-record.schema.json",
+  "title": "Claim Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "claim_id",
+    "event_id",
+    "claim_kind",
+    "epistemic_class",
+    "statement",
+    "claim_grade",
+    "grade_updated_at",
+    "status",
+    "source_observation_ids",
+    "evidence_ids",
+    "dynamic_value_policy",
+    "superseded_by_claim_id",
+    "last_updated",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "claim_id": {
+      "type": "string",
+      "pattern": "^clm-[A-Za-z0-9._-]+$"
+    },
+    "event_id": {
+      "type": "string",
+      "pattern": "^evt-[A-Za-z0-9._-]+$"
+    },
+    "claim_kind": {
+      "enum": [
+        "existence",
+        "time",
+        "quantity",
+        "identity",
+        "behavior",
+        "legal_status",
+        "causal",
+        "motive",
+        "intent",
+        "prediction",
+        "battle_result",
+        "technical_performance",
+        "commercial_scale",
+        "other"
+      ]
+    },
+    "epistemic_class": {
+      "enum": [
+        "fact",
+        "forecast",
+        "correlation",
+        "causality",
+        "opinion"
+      ]
+    },
+    "statement": {
+      "type": "string",
+      "minLength": 1
+    },
+    "claim_grade": {
+      "enum": [
+        "A",
+        "B",
+        "C",
+        "D"
+      ],
+      "description": "Claim Grade A-D only; not Risk Variable A-D."
+    },
+    "grade_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "status": {
+      "enum": [
+        "developing",
+        "accepted",
+        "disputed",
+        "refuted",
+        "superseded",
+        "withdrawn"
+      ]
+    },
+    "source_observation_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^sob-[A-Za-z0-9._-]+$"
+      }
+    },
+    "evidence_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^evd-[A-Za-z0-9._-]+$"
+      }
+    },
+    "dynamic_value_policy": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "value_type",
+            "unit",
+            "materiality_rule",
+            "absolute_delta",
+            "relative_delta"
+          ],
+          "properties": {
+            "value_type": {
+              "enum": [
+                "number",
+                "integer"
+              ]
+            },
+            "unit": {
+              "type": "string",
+              "minLength": 1
+            },
+            "materiality_rule": {
+              "enum": [
+                "none",
+                "any_change",
+                "absolute",
+                "relative",
+                "either"
+              ]
+            },
+            "absolute_delta": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "minimum": 0
+            },
+            "relative_delta": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "minimum": 0
+            }
+          }
+        }
+      ]
+    },
+    "superseded_by_claim_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^clm-[A-Za-z0-9._-]+$"
+    },
+    "last_updated": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "superseded"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "then": {
+        "properties": {
+          "superseded_by_claim_id": {
+            "type": "string",
+            "pattern": "^clm-[A-Za-z0-9._-]+$"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/claim-value-observation.schema.json
+++ b/schemas/claim-value-observation.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/claim-value-observation.schema.json",
+  "title": "Claim Dynamic Value Observation",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "value_observation_id",
+    "claim_id",
+    "value",
+    "unit",
+    "as_of",
+    "recorded_at",
+    "claim_grade",
+    "source_observation_ids",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "value_observation_id": {
+      "type": "string",
+      "pattern": "^cvo-[A-Za-z0-9._-]+$"
+    },
+    "claim_id": {
+      "type": "string",
+      "pattern": "^clm-[A-Za-z0-9._-]+$"
+    },
+    "value": {
+      "type": "number"
+    },
+    "unit": {
+      "type": "string",
+      "minLength": 1
+    },
+    "as_of": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "recorded_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "claim_grade": {
+      "enum": [
+        "A",
+        "B",
+        "C",
+        "D"
+      ]
+    },
+    "source_observation_ids": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^sob-[A-Za-z0-9._-]+$"
+      }
+    },
+    "notes": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/event-state-record.schema.json
+++ b/schemas/event-state-record.schema.json
@@ -1,0 +1,213 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/event-state-record.schema.json",
+  "title": "Event State Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "event_id",
+    "display_title",
+    "event_type",
+    "domain",
+    "fingerprint_basis",
+    "fingerprint",
+    "first_seen",
+    "last_updated",
+    "intelligence_priority",
+    "lifecycle",
+    "claim_ids",
+    "source_observation_ids",
+    "material_markers",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "event_id": {
+      "type": "string",
+      "pattern": "^evt-[A-Za-z0-9._-]+$"
+    },
+    "display_title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 240
+    },
+    "event_type": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 120
+    },
+    "domain": {
+      "enum": [
+        "china_policy",
+        "macro",
+        "financial_markets",
+        "industry",
+        "technology",
+        "diplomacy",
+        "military",
+        "taiwan_strait",
+        "south_china_sea",
+        "sanctions_export_controls",
+        "corporate",
+        "disaster",
+        "physical_ai",
+        "war_unmanned_systems",
+        "energy",
+        "shipping",
+        "supply_chain",
+        "global_risk",
+        "other"
+      ]
+    },
+    "fingerprint_basis": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "actors",
+        "actions",
+        "objects",
+        "locations",
+        "time_window_key",
+        "consequences"
+      ],
+      "properties": {
+        "actors": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "actions": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "objects": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "locations": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "time_window_key": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 120
+        },
+        "consequences": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "fingerprint": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "first_seen": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "last_updated": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "intelligence_priority": {
+      "enum": [
+        "P0",
+        "P1",
+        "P2",
+        "P3"
+      ]
+    },
+    "lifecycle": {
+      "enum": [
+        "candidate",
+        "developing",
+        "confirmed",
+        "contained",
+        "reversed",
+        "closed"
+      ]
+    },
+    "claim_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^clm-[A-Za-z0-9._-]+$"
+      }
+    },
+    "source_observation_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^sob-[A-Za-z0-9._-]+$"
+      }
+    },
+    "material_markers": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "casualty_revision",
+          "policy_formalized",
+          "investigation_to_charge",
+          "negotiation_to_agreement",
+          "declaration_to_budget",
+          "budget_to_procurement",
+          "procurement_to_delivery",
+          "demo_to_deployment",
+          "test_to_scaled_production",
+          "threat_to_attack",
+          "shipping_risk_to_suspension",
+          "expectation_to_real_price_transmission",
+          "claim_grade_upgrade",
+          "claim_grade_downgrade",
+          "quantitative_revision",
+          "behavioral_escalation",
+          "behavioral_deescalation",
+          "other"
+        ]
+      }
+    },
+    "notes": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/event.schema.json
+++ b/schemas/event.schema.json
@@ -53,7 +53,8 @@
       "enum": [
         "P0",
         "P1",
-        "P2"
+        "P2",
+        "P3"
       ]
     },
     "observation_domains": {

--- a/schemas/evidence.schema.json
+++ b/schemas/evidence.schema.json
@@ -98,6 +98,7 @@
     "target_type": {
       "enum": [
         "event",
+        "claim",
         "edge",
         "scenario"
       ]

--- a/schemas/material-change-assessment.schema.json
+++ b/schemas/material-change-assessment.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/material-change-assessment.schema.json",
+  "title": "Material Change Assessment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "assessment_id",
+    "event_id",
+    "previous_state_ref",
+    "current_state_ref",
+    "material",
+    "change_types",
+    "changed_claim_ids",
+    "numeric_change_refs",
+    "priority_from",
+    "priority_to",
+    "reasons",
+    "assessed_at",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "assessment_id": {
+      "type": "string",
+      "pattern": "^mca-[A-Za-z0-9._-]+$"
+    },
+    "event_id": {
+      "type": "string",
+      "pattern": "^evt-[A-Za-z0-9._-]+$"
+    },
+    "previous_state_ref": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "current_state_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "material": {
+      "type": "boolean"
+    },
+    "change_types": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "new_event",
+          "material_marker_added",
+          "material_marker_removed",
+          "priority_change",
+          "numeric_material_change",
+          "claim_grade_change",
+          "lifecycle_change",
+          "non_material_update"
+        ]
+      }
+    },
+    "changed_claim_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^clm-[A-Za-z0-9._-]+$"
+      }
+    },
+    "numeric_change_refs": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^cvo-[A-Za-z0-9._-]+$"
+      }
+    },
+    "priority_from": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "P0",
+        "P1",
+        "P2",
+        "P3",
+        null
+      ]
+    },
+    "priority_to": {
+      "enum": [
+        "P0",
+        "P1",
+        "P2",
+        "P3"
+      ]
+    },
+    "reasons": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "assessed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/scripts/validate_schemas.py
+++ b/scripts/validate_schemas.py
@@ -27,6 +27,10 @@ PAIRS = {
     "source_observation": ("schemas/source-observation.schema.json", "examples/synthetic/source-observation.json"),
     "source_reputation_record": ("schemas/source-reputation-record.schema.json", "examples/synthetic/source-reputation-record.json"),
     "source_concentration_assessment": ("schemas/source-concentration-assessment.schema.json", "examples/synthetic/source-concentration-assessment.json"),
+    "event_state_record": ("schemas/event-state-record.schema.json", "examples/synthetic/event-state-record.json"),
+    "claim_record": ("schemas/claim-record.schema.json", "examples/synthetic/claim-record.json"),
+    "claim_value_observation": ("schemas/claim-value-observation.schema.json", "examples/synthetic/claim-value-observation.json"),
+    "material_change_assessment": ("schemas/material-change-assessment.schema.json", "examples/synthetic/material-change-assessment.json"),
 }
 
 def load(path):
@@ -119,6 +123,23 @@ def semantic_errors(name, obj):
                 errors.append("SINGLE_ORIGIN must set single_source_bias=true")
         if obj["state"] == "DIVERSE" and obj["known_independence_group_count"] < 2:
             errors.append("DIVERSE requires at least two known independence groups")
+    elif name == "claim_record":
+        policy = obj["dynamic_value_policy"]
+        if policy is not None:
+            rule = policy["materiality_rule"]
+            if rule == "absolute" and policy["absolute_delta"] is None:
+                errors.append("absolute materiality rule requires absolute_delta")
+            if rule == "relative" and policy["relative_delta"] is None:
+                errors.append("relative materiality rule requires relative_delta")
+            if rule == "either" and policy["absolute_delta"] is None and policy["relative_delta"] is None:
+                errors.append("either materiality rule requires at least one threshold")
+    elif name == "material_change_assessment":
+        if obj["material"] and "non_material_update" in obj["change_types"]:
+            errors.append("material assessment cannot include non_material_update")
+        if not obj["material"] and obj["change_types"] != ["non_material_update"]:
+            errors.append("non-material assessment must contain only non_material_update")
+        if "priority_change" in obj["change_types"] and obj["priority_from"] == obj["priority_to"]:
+            errors.append("priority_change requires different from/to values")
     return errors
 
 def main():

--- a/src/psrro/__init__.py
+++ b/src/psrro/__init__.py
@@ -1,3 +1,9 @@
+from .intelligence_events import (
+    EventClaimStateStore,
+    detect_material_change,
+    event_fingerprint,
+    numeric_material_change,
+)
 from .intelligence_sources import (
     SourceStateStore,
     access_disclosure_required,
@@ -17,6 +23,10 @@ from .quantification import (
 )
 
 __all__ = [
+    "EventClaimStateStore",
+    "detect_material_change",
+    "event_fingerprint",
+    "numeric_material_change",
     "SourceStateStore",
     "access_disclosure_required",
     "assess_source_concentration",

--- a/src/psrro/intelligence_events.py
+++ b/src/psrro/intelligence_events.py
@@ -1,0 +1,233 @@
+"""Phase 3R-02 event / claim state primitives.
+
+The module persists V0.3 event-cluster and atomic-claim state. It does not
+perform semantic news extraction or decide P0 automatically.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Mapping, Sequence
+
+SAFE_COMPONENT = re.compile(r"^[A-Za-z0-9._-]+$")
+MATERIAL_LIFECYCLES = {"confirmed", "contained", "reversed", "closed"}
+
+
+def _safe_component(value: str, label: str) -> str:
+    if not SAFE_COMPONENT.fullmatch(value) or value in {".", ".."}:
+        raise ValueError(f"unsafe {label}: {value!r}")
+    return value
+
+
+def _write_json(path: Path, obj: Mapping) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(obj, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    path.write_text(payload, encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_text(value: str) -> str:
+    return " ".join(value.casefold().split())
+
+
+def _normalize_list(values: Sequence[str]) -> list[str]:
+    return sorted({_normalize_text(v) for v in values if _normalize_text(v)})
+
+
+def event_fingerprint(basis: Mapping) -> str:
+    """Stable fingerprint from V0.3 Actor+Action+Object+Location+Time+Consequence."""
+    normalized = {
+        "actors": _normalize_list(basis.get("actors", [])),
+        "actions": _normalize_list(basis.get("actions", [])),
+        "objects": _normalize_list(basis.get("objects", [])),
+        "locations": _normalize_list(basis.get("locations", [])),
+        "time_window_key": _normalize_text(str(basis.get("time_window_key", ""))),
+        "consequences": _normalize_list(basis.get("consequences", [])),
+    }
+    if not normalized["actors"] or not normalized["actions"] or not normalized["time_window_key"]:
+        raise ValueError("fingerprint requires actors, actions, and time_window_key")
+    payload = json.dumps(normalized, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+class EventClaimStateStore:
+    """Minimal deterministic file-backed event/claim state store."""
+
+    def __init__(self, root: str | Path):
+        self.root = Path(root)
+
+    def put_event(self, record: Mapping) -> Path:
+        event_id = _safe_component(str(record["event_id"]), "event_id")
+        path = self.root / "events" / f"{event_id}.json"
+        _write_json(path, record)
+        return path
+
+    def get_event(self, event_id: str) -> dict:
+        event_id = _safe_component(event_id, "event_id")
+        return _load_json(self.root / "events" / f"{event_id}.json")
+
+    def put_claim(self, record: Mapping) -> Path:
+        claim_id = _safe_component(str(record["claim_id"]), "claim_id")
+        path = self.root / "claims" / f"{claim_id}.json"
+        _write_json(path, record)
+        return path
+
+    def get_claim(self, claim_id: str) -> dict:
+        claim_id = _safe_component(claim_id, "claim_id")
+        return _load_json(self.root / "claims" / f"{claim_id}.json")
+
+    def put_value_observation(self, record: Mapping) -> Path:
+        value_id = _safe_component(str(record["value_observation_id"]), "value_observation_id")
+        claim_id = _safe_component(str(record["claim_id"]), "claim_id")
+        path = self.root / "claim-values" / claim_id / f"{value_id}.json"
+        _write_json(path, record)
+        return path
+
+    def get_value_observation(self, claim_id: str, value_observation_id: str) -> dict:
+        claim_id = _safe_component(claim_id, "claim_id")
+        value_id = _safe_component(value_observation_id, "value_observation_id")
+        return _load_json(self.root / "claim-values" / claim_id / f"{value_id}.json")
+
+    def put_material_change(self, record: Mapping) -> Path:
+        assessment_id = _safe_component(str(record["assessment_id"]), "assessment_id")
+        event_id = _safe_component(str(record["event_id"]), "event_id")
+        path = self.root / "material-change" / event_id / f"{assessment_id}.json"
+        _write_json(path, record)
+        return path
+
+
+def numeric_material_change(
+    policy: Mapping | None,
+    previous_value: float,
+    current_value: float,
+) -> tuple[bool, str]:
+    """Apply claim-specific materiality without inventing a global numeric threshold."""
+    if policy is None:
+        return False, "no dynamic-value policy"
+
+    rule = policy["materiality_rule"]
+    absolute_delta = abs(float(current_value) - float(previous_value))
+
+    if rule == "none":
+        return False, "materiality rule is none"
+    if rule == "any_change":
+        return absolute_delta > 0, "any-change rule"
+
+    absolute_threshold = policy.get("absolute_delta")
+    relative_threshold = policy.get("relative_delta")
+    absolute_hit = (
+        absolute_threshold is not None and absolute_delta >= float(absolute_threshold)
+    )
+
+    relative_hit = False
+    relative_defined = float(previous_value) != 0
+    if relative_threshold is not None and relative_defined:
+        relative_delta = absolute_delta / abs(float(previous_value))
+        relative_hit = relative_delta >= float(relative_threshold)
+
+    if rule == "absolute":
+        return absolute_hit, "absolute-delta rule"
+    if rule == "relative":
+        if not relative_defined:
+            return False, "relative delta undefined from zero baseline"
+        return relative_hit, "relative-delta rule"
+    if rule == "either":
+        if absolute_threshold is None and relative_threshold is None:
+            raise ValueError("either rule requires at least one threshold")
+        return absolute_hit or relative_hit, "either absolute/relative rule"
+
+    raise ValueError(f"unsupported materiality rule: {rule}")
+
+
+def detect_material_change(
+    previous: Mapping | None,
+    current: Mapping,
+    *,
+    changed_claim_ids: Sequence[str] = (),
+    numeric_change_refs: Sequence[str] = (),
+    claim_grade_changed: bool = False,
+    assessment_id: str = "mca-derived",
+    current_state_ref: str = "current",
+    previous_state_ref: str | None = None,
+    assessed_at: str = "1970-01-01T00:00:00Z",
+) -> dict:
+    """Detect structural update, excluding display-title/source-list noise."""
+    change_types: list[str] = []
+    reasons: list[str] = []
+
+    if previous is None:
+        change_types.append("new_event")
+        reasons.append("new event entered the candidate/event state")
+        material = True
+        priority_from = None
+    else:
+        if previous["event_id"] != current["event_id"]:
+            raise ValueError("cannot compare different event_id values")
+        if previous["fingerprint"] != current["fingerprint"]:
+            raise ValueError("event fingerprint drift requires re-clustering, not in-place comparison")
+
+        priority_from = previous["intelligence_priority"]
+        if priority_from != current["intelligence_priority"]:
+            change_types.append("priority_change")
+            reasons.append(
+                f"priority changed {priority_from}->{current['intelligence_priority']}"
+            )
+
+        previous_markers = set(previous.get("material_markers", []))
+        current_markers = set(current.get("material_markers", []))
+        added = sorted(current_markers - previous_markers)
+        removed = sorted(previous_markers - current_markers)
+        if added:
+            change_types.append("material_marker_added")
+            reasons.append("material markers added: " + ", ".join(added))
+        if removed:
+            change_types.append("material_marker_removed")
+            reasons.append("material markers removed: " + ", ".join(removed))
+
+        if (
+            previous.get("lifecycle") != current.get("lifecycle")
+            and (
+                previous.get("lifecycle") in MATERIAL_LIFECYCLES
+                or current.get("lifecycle") in MATERIAL_LIFECYCLES
+            )
+        ):
+            change_types.append("lifecycle_change")
+            reasons.append(
+                f"lifecycle changed {previous.get('lifecycle')}->{current.get('lifecycle')}"
+            )
+
+        if claim_grade_changed:
+            change_types.append("claim_grade_change")
+            reasons.append("one or more material claim grades changed")
+
+        if numeric_change_refs:
+            change_types.append("numeric_material_change")
+            reasons.append("one or more dynamic claims crossed their own materiality rule")
+
+        material = bool(change_types)
+        if not material:
+            change_types.append("non_material_update")
+            reasons.append("only non-material metadata/title/source-list update detected")
+
+    return {
+        "schema_version": "0.1.0",
+        "assessment_id": assessment_id,
+        "event_id": current["event_id"],
+        "previous_state_ref": previous_state_ref,
+        "current_state_ref": current_state_ref,
+        "material": material,
+        "change_types": change_types,
+        "changed_claim_ids": sorted(set(changed_claim_ids)),
+        "numeric_change_refs": sorted(set(numeric_change_refs)),
+        "priority_from": priority_from,
+        "priority_to": current["intelligence_priority"],
+        "reasons": reasons,
+        "assessed_at": assessed_at,
+        "sensitivity": current.get("sensitivity", "public"),
+    }

--- a/src/psrro/intelligence_events.py
+++ b/src/psrro/intelligence_events.py
@@ -101,6 +101,13 @@ class EventClaimStateStore:
         _write_json(path, record)
         return path
 
+    def get_material_change(self, event_id: str, assessment_id: str) -> dict:
+        event_id = _safe_component(event_id, "event_id")
+        assessment_id = _safe_component(assessment_id, "assessment_id")
+        return _load_json(
+            self.root / "material-change" / event_id / f"{assessment_id}.json"
+        )
+
 
 def numeric_material_change(
     policy: Mapping | None,

--- a/tests/test_intelligence_events.py
+++ b/tests/test_intelligence_events.py
@@ -1,0 +1,145 @@
+import copy
+import tempfile
+import unittest
+
+from src.psrro.intelligence_events import (
+    EventClaimStateStore,
+    detect_material_change,
+    event_fingerprint,
+    numeric_material_change,
+)
+
+
+def basis():
+    return {
+        "actors": ["Actor A"],
+        "actions": ["Deploy"],
+        "objects": ["System X"],
+        "locations": ["Region 1"],
+        "time_window_key": "2026-08-31",
+        "consequences": ["Operational change"],
+    }
+
+
+def event(priority="P3", title="Headline A", markers=None, lifecycle="developing"):
+    fp = event_fingerprint(basis())
+    return {
+        "event_id": "evt-synthetic",
+        "display_title": title,
+        "fingerprint": fp,
+        "intelligence_priority": priority,
+        "material_markers": markers or [],
+        "lifecycle": lifecycle,
+        "sensitivity": "public",
+    }
+
+
+class FingerprintTests(unittest.TestCase):
+    def test_order_case_and_whitespace_do_not_change_fingerprint(self):
+        left = basis()
+        right = {
+            "actors": ["  ACTOR   A "],
+            "actions": ["deploy"],
+            "objects": ["system x"],
+            "locations": ["region 1"],
+            "time_window_key": " 2026-08-31 ",
+            "consequences": ["operational change"],
+        }
+        self.assertEqual(event_fingerprint(left), event_fingerprint(right))
+
+    def test_display_title_is_not_part_of_fingerprint(self):
+        self.assertEqual(event("P3", "Headline A")["fingerprint"], event("P3", "Totally different headline")["fingerprint"])
+
+    def test_missing_actor_action_or_time_fails_closed(self):
+        bad = basis()
+        bad["actors"] = []
+        with self.assertRaises(ValueError):
+            event_fingerprint(bad)
+
+
+class NumericMaterialityTests(unittest.TestCase):
+    def test_absolute_threshold(self):
+        policy = {"materiality_rule": "absolute", "absolute_delta": 10, "relative_delta": None}
+        self.assertFalse(numeric_material_change(policy, 100, 105)[0])
+        self.assertTrue(numeric_material_change(policy, 100, 110)[0])
+
+    def test_relative_threshold(self):
+        policy = {"materiality_rule": "relative", "absolute_delta": None, "relative_delta": 0.1}
+        self.assertFalse(numeric_material_change(policy, 100, 105)[0])
+        self.assertTrue(numeric_material_change(policy, 100, 111)[0])
+
+    def test_relative_zero_baseline_fails_closed(self):
+        policy = {"materiality_rule": "relative", "absolute_delta": None, "relative_delta": 0.1}
+        result, reason = numeric_material_change(policy, 0, 10)
+        self.assertFalse(result)
+        self.assertIn("undefined", reason)
+
+    def test_either_can_use_absolute_when_zero_baseline(self):
+        policy = {"materiality_rule": "either", "absolute_delta": 5, "relative_delta": 0.1}
+        self.assertTrue(numeric_material_change(policy, 0, 5)[0])
+
+
+class MaterialChangeTests(unittest.TestCase):
+    def test_title_only_update_is_not_material(self):
+        old = event(title="Old title")
+        new = event(title="New title")
+        result = detect_material_change(old, new)
+        self.assertFalse(result["material"])
+        self.assertEqual(result["change_types"], ["non_material_update"])
+
+    def test_p3_to_p2_is_material(self):
+        result = detect_material_change(event("P3"), event("P2"))
+        self.assertTrue(result["material"])
+        self.assertIn("priority_change", result["change_types"])
+
+    def test_threat_to_attack_marker_is_material(self):
+        result = detect_material_change(
+            event(markers=[]),
+            event(markers=["threat_to_attack"]),
+        )
+        self.assertTrue(result["material"])
+        self.assertIn("material_marker_added", result["change_types"])
+
+    def test_numeric_change_ref_is_material(self):
+        result = detect_material_change(
+            event(),
+            event(),
+            numeric_change_refs=["cvo-2"],
+            changed_claim_ids=["clm-1"],
+        )
+        self.assertTrue(result["material"])
+        self.assertIn("numeric_material_change", result["change_types"])
+
+    def test_fingerprint_drift_requires_reclustering(self):
+        old = event()
+        new = copy.deepcopy(old)
+        changed_basis = basis()
+        changed_basis["actors"] = ["Actor B"]
+        new["fingerprint"] = event_fingerprint(changed_basis)
+        with self.assertRaises(ValueError):
+            detect_material_change(old, new)
+
+
+class StoreTests(unittest.TestCase):
+    def test_event_claim_and_dynamic_value_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EventClaimStateStore(tmp)
+            ev = {"event_id": "evt-1", "value": 1}
+            cl = {"claim_id": "clm-1", "value": 2}
+            val = {"value_observation_id": "cvo-1", "claim_id": "clm-1", "value": 3}
+            store.put_event(ev)
+            store.put_claim(cl)
+            store.put_value_observation(val)
+            self.assertEqual(store.get_event("evt-1"), ev)
+            self.assertEqual(store.get_claim("clm-1"), cl)
+            self.assertEqual(store.get_value_observation("clm-1", "cvo-1"), val)
+
+    def test_unsafe_identifier_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EventClaimStateStore(tmp)
+            with self.assertRaises(ValueError):
+                store.put_event({"event_id": "../escape"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_intelligence_events.py
+++ b/tests/test_intelligence_events.py
@@ -47,6 +47,12 @@ class FingerprintTests(unittest.TestCase):
         }
         self.assertEqual(event_fingerprint(left), event_fingerprint(right))
 
+    def test_fingerprint_has_stable_known_value(self):
+        self.assertEqual(
+            event_fingerprint(basis()),
+            "cb04875bb8484e37279a31a4310aa13a019d2b2bc4e325cc23fd27c9ca250465",
+        )
+
     def test_display_title_is_not_part_of_fingerprint(self):
         self.assertEqual(event("P3", "Headline A")["fingerprint"], event("P3", "Totally different headline")["fingerprint"])
 
@@ -127,12 +133,15 @@ class StoreTests(unittest.TestCase):
             ev = {"event_id": "evt-1", "value": 1}
             cl = {"claim_id": "clm-1", "value": 2}
             val = {"value_observation_id": "cvo-1", "claim_id": "clm-1", "value": 3}
+            change = {"assessment_id": "mca-1", "event_id": "evt-1", "value": 4}
             store.put_event(ev)
             store.put_claim(cl)
             store.put_value_observation(val)
+            store.put_material_change(change)
             self.assertEqual(store.get_event("evt-1"), ev)
             self.assertEqual(store.get_claim("clm-1"), cl)
             self.assertEqual(store.get_value_observation("clm-1", "cvo-1"), val)
+            self.assertEqual(store.get_material_change("evt-1", "mca-1"), change)
 
     def test_unsafe_identifier_rejected(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_intelligence_events.py
+++ b/tests/test_intelligence_events.py
@@ -50,7 +50,7 @@ class FingerprintTests(unittest.TestCase):
     def test_fingerprint_has_stable_known_value(self):
         self.assertEqual(
             event_fingerprint(basis()),
-            "cb04875bb8484e37279a31a4310aa13a019d2b2bc4e325cc23fd27c9ca250465",
+            "b113d7a1a16941a8591eb67f9be5b6d220f15eb00e2f1577421e4f62c40aca87",
         )
 
     def test_display_title_is_not_part_of_fingerprint(self):


### PR DESCRIPTION
Closes #26

## Implements

- Restores full P0-P3 event importance compatibility
- Allows Evidence to target atomic Claims
- Event State Record with stable V0.3 fingerprint basis
- Atomic Claim Record with Claim Grade A-D namespace
- Dynamic Claim Value Observation
- Material Change Assessment
- deterministic event fingerprinting
- claim-specific numeric materiality
- deterministic file-backed EventClaimStateStore
- synthetic tests and unified validation

## Preserved V0.3 invariants

- headline wording alone does not create a new event
- Event Cluster identity uses Actor + Action + Object + Location + Time Window + Consequence
- P3 persists as background but remains non-push by default
- old/new dynamic numbers keep timestamp/source/Claim Grade
- no global numeric materiality threshold
- threat→attack / budget→procurement / demo→deployment and related transitions are representable as explicit material markers
- non-material title/source-list updates stay non-material
- Claim Grade A-D is not Risk Variable A-D

## Non-goals

No crawler, semantic extractor, automatic P0 grading, systemic-risk update, alert notification, or Physical AI auto-routing.

Synthetic public-safe fixtures only.
