### PR TITLE
Phase 3R-05: judgment memory and posterior learning v0.1

### DIFF
--- a/docs/JUDGMENT-MEMORY.md
+++ b/docs/JUDGMENT-MEMORY.md
@@ -25,7 +25,15 @@ They must not be silently rewritten after outcomes become known.
 It rejects:
 - same ID + changed content.
 
-Posterior revisions and Alert History use the same rule.
+Judgment Outcome, Posterior Revision and Alert History use the same rule.
+
+This creates a deliberate split:
+
+- **Judgment Record** = what the system believed at that time.
+- **Judgment Outcome Record** = what later evidence showed.
+- **Posterior Revision** = why the belief changed.
+
+This preserves the V0.3 `later_result / error_type / posterior_update` semantics without mutating the original historical judgment.
 
 ## 2. Judgment Ledger
 
@@ -40,13 +48,26 @@ A record captures the V0.3 concepts:
 - tail risk;
 - watch / falsification signals;
 - source set;
-- source limitations;
-- later result;
-- outcome status;
-- error types;
-- posterior revision refs.
+- source limitations.
 
-`later_result` does not replace `current_finding`.
+The original record stops there. It is immutable.
+
+### Judgment Outcome Record
+
+Later evaluation is appended separately:
+
+- outcome_status;
+- later_result;
+- error_types;
+- posterior revision refs;
+- previous outcome ref;
+- evaluated_at.
+
+A judgment may evolve:
+
+`unresolved → partially_resolved → resolved`
+
+without rewriting its original finding.
 
 ## 3. Predicted paths
 
@@ -110,9 +131,11 @@ Transport status is separate because R4/R5 do not implement notification deliver
 
 ## 7. Calibration
 
-`summarize_judgment_calibration` counts:
+`summarize_judgment_calibration` selects the latest Outcome Record for each Judgment, then counts:
 - resolved / partially resolved / unresolved;
 - error types.
+
+All historical Outcome Records remain stored for replay; the current calibration does not double-count one Judgment merely because it had several evaluation updates.
 
 Supported error examples:
 - source_error

--- a/docs/JUDGMENT-MEMORY.md
+++ b/docs/JUDGMENT-MEMORY.md
@@ -1,0 +1,151 @@
+# Judgment Memory & Posterior Learning — Phase 3R-05 v0.1
+
+## Purpose
+
+V0.3 requires the system to remember:
+- what it knew then;
+- what it did not know;
+- what it predicted;
+- what signals would prove/disprove it;
+- what happened later;
+- how the judgment changed.
+
+R5 makes that memory durable.
+
+## 1. Append-only principle
+
+Judgments are historical records.
+
+They must not be silently rewritten after outcomes become known.
+
+`JudgmentMemoryStore` therefore permits:
+- first append;
+- exact idempotent replay.
+
+It rejects:
+- same ID + changed content.
+
+Posterior revisions and Alert History use the same rule.
+
+## 2. Judgment Ledger
+
+A record captures the V0.3 concepts:
+- timestamp;
+- Event/Claim/Edge/Scenario refs;
+- initial Claim Grade where applicable;
+- P0-P3;
+- system-state refs;
+- current finding;
+- predicted paths;
+- tail risk;
+- watch / falsification signals;
+- source set;
+- source limitations;
+- later result;
+- outcome status;
+- error types;
+- posterior revision refs.
+
+`later_result` does not replace `current_finding`.
+
+## 3. Predicted paths
+
+Predictions use semantic likelihood bands:
+- remote
+- possible
+- plausible
+- likely
+- unknown
+
+v0.1 does not invent a universal numerical probability model.
+
+## 4. Posterior Revision
+
+Conceptual contract:
+
+`Prior + New Evidence + Source Reliability + Counter Evidence → Posterior`
+
+Persist:
+- prior semantic state;
+- posterior semantic state;
+- supporting/new evidence;
+- refuting evidence;
+- Source Reputation refs;
+- Counterevidence Assessment refs;
+- direction;
+- rationale.
+
+Direction:
+- strengthen
+- weaken
+- unchanged
+- falsified
+- reclassified
+- unknown
+
+## 5. Claim Grade discipline
+
+Claim Grade A/B/C/D is not a numeric ordinal score.
+
+Especially:
+- D = analysis/opinion/prediction.
+
+R5 therefore has no:
+- A=4/B=3/C=2/D=1 mapping;
+- automatic average confidence;
+- grade arithmetic.
+
+A revision may record B→A or D→D or D→C, but semantics/rationale remain explicit.
+
+## 6. Alert History
+
+Every R4 gate decision can be remembered, including suppression.
+
+This matters because:
+- duplicate suppression needs history;
+- replay needs to know what the system chose not to send;
+- false-positive/late/early review requires historical decisions.
+
+Transport status is separate because R4/R5 do not implement notification delivery.
+
+## 7. Calibration
+
+`summarize_judgment_calibration` counts:
+- resolved / partially resolved / unresolved;
+- error types.
+
+Supported error examples:
+- source_error
+- overreaction
+- underreaction
+- timing_error
+- omitted_variable
+- correlation_as_causality
+- rhetoric_overweight
+- technology_maturity_overestimate
+- execution_delay
+- none / unknown
+
+There is deliberately no single `accuracy_score`.
+
+## 8. Dual calibration
+
+### Source Ledger
+Who is reliable in what domain / Claim type?
+
+### Judgment Ledger
+Where does the system itself systematically fail?
+
+These must remain separate.
+
+## 9. Phase boundary
+
+R5 adds memory and learning records.
+
+R6 will use that persistent state to maintain the first explicit Chain Watch:
+Climate / El Niño
+→ Food & Energy
+→ Inflation
+→ Fed
+→ UST / Financial Conditions
+→ AI CapEx / Valuation / Financing Stress.

--- a/docs/PROJECT-STATE.md
+++ b/docs/PROJECT-STATE.md
@@ -108,9 +108,9 @@ Phase 3R-00 and 3R-00A are complete.
 
 The canonical operational baseline is now the reconciled China Intelligence / Physical AI / Global Risk Resonance V0.3 specification. Phase 3R is explicitly an engineering upgrade around that working logic, not a redesign.
 
-R1 Source / Evidence Persistence, R2 Event / Claim State, and R3 Behavior / Counterevidence / Structural Delta are COMPLETE.
+R1 Source / Evidence Persistence, R2 Event / Claim State, R3 Behavior / Counterevidence / Structural Delta, and R4 Precision Alert Gate are COMPLETE.
 
-Current node: **R4 — Precision Alert Gate**.
+Current node: **R5 — Judgment Memory / Posterior Learning**.
 
 Priority sequence:
 - Source Registry + Source Reputation Ledger;
@@ -118,8 +118,8 @@ Priority sequence:
 - Event + Claim durable state;
 - Material Change and event fingerprints;
 - Behavior/System structural deltas — complete;
-- alert suppression/hysteresis — current;
-- Judgment Ledger / posterior learning;
+- alert suppression/hysteresis — complete;
+- Judgment Ledger / posterior learning — current;
 - first Chain Watch: climate→food/energy→inflation→Fed→UST/financial conditions→AI CapEx/valuation.
 
 Namespace rule:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -80,18 +80,19 @@ Separate private operational-state layer established, pinned to public method ve
 - [x] Counterevidence / falsification
 - [x] Risk Variable / Edge / Coupling / Buffer / Scenario delta tracking
 
-#### R4 — Precision Alert Gate — CURRENT
-- [~] P0-P3 gate implementation
-- [~] Trigger A/B/C compatibility rules
-- [~] duplicate suppression / cooldown / hysteresis
-- [~] "no substantive change = no notification"
-- [~] scheduled brief vs interrupt alert separation
+#### R4 — Precision Alert Gate — COMPLETE
+- [x] P0-P3 gate implementation
+- [x] Trigger A/B/C compatibility rules
+- [x] duplicate suppression / cooldown / hysteresis
+- [x] "no substantive change = no notification"
+- [x] scheduled brief vs interrupt alert separation
 
-#### R5 — Judgment Memory / Learning
-- [ ] Judgment Ledger
-- [ ] Alert History
-- [ ] Posterior Revision
-- [ ] source + judgment calibration
+#### R5 — Judgment Memory / Learning — CURRENT
+- [~] immutable Judgment Ledger
+- [~] append-only Judgment Outcome history
+- [~] Alert History
+- [~] Posterior Revision
+- [~] source + judgment calibration
 
 #### R6 — Chain Watch
 - [ ] climate→food/energy→inflation→Fed→UST/financial conditions→AI CapEx/valuation

--- a/examples/synthetic/alert-history-record.json
+++ b/examples/synthetic/alert-history-record.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "0.1.0",
+  "alert_history_id": "ahs-synthetic-r5-001",
+  "candidate_id": "ogc-synthetic-r4-001",
+  "decision_id": "ogd-synthetic-r4-001",
+  "delivery_mode": "interrupt_alert",
+  "outcome": "EMIT",
+  "trigger_codes": [
+    "TRIGGER_A_RESONANCE"
+  ],
+  "suppression_codes": [],
+  "state_signature": "9a56c387d5ea6d49cdee2ddac765d3f0254305b4d35199225798fbdac8eeae8f",
+  "decided_at": "2026-08-31T03:05:00Z",
+  "recorded_at": "2026-08-31T03:06:00Z",
+  "related_prior_alert_id": null,
+  "later_evaluation": "unreviewed",
+  "transport_status": "not_applicable",
+  "sensitivity": "public"
+}

--- a/examples/synthetic/judgment-calibration-summary.json
+++ b/examples/synthetic/judgment-calibration-summary.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "0.1.0",
+  "summary_id": "jcs-synthetic-r5-001",
+  "judgment_ids": [
+    "jdg-synthetic-r5-001"
+  ],
+  "total_count": 1,
+  "resolved_count": 0,
+  "partially_resolved_count": 0,
+  "unresolved_count": 1,
+  "error_type_counts": {
+    "none": 1,
+    "source_error": 0,
+    "overreaction": 0,
+    "underreaction": 0,
+    "timing_error": 0,
+    "omitted_variable": 0,
+    "correlation_as_causality": 0,
+    "rhetoric_overweight": 0,
+    "technology_maturity_overestimate": 0,
+    "execution_delay": 0,
+    "unknown": 0
+  },
+  "generated_at": "2026-08-31T05:10:00Z",
+  "sensitivity": "public"
+}

--- a/examples/synthetic/judgment-calibration-summary.json
+++ b/examples/synthetic/judgment-calibration-summary.json
@@ -22,5 +22,8 @@
     "unknown": 0
   },
   "generated_at": "2026-08-31T05:10:00Z",
-  "sensitivity": "public"
+  "sensitivity": "public",
+  "outcome_ids": [
+    "jot-synthetic-r5-001"
+  ]
 }

--- a/examples/synthetic/judgment-calibration-summary.json
+++ b/examples/synthetic/judgment-calibration-summary.json
@@ -5,9 +5,9 @@
     "jdg-synthetic-r5-001"
   ],
   "total_count": 1,
-  "resolved_count": 0,
+  "resolved_count": 1,
   "partially_resolved_count": 0,
-  "unresolved_count": 1,
+  "unresolved_count": 0,
   "error_type_counts": {
     "none": 1,
     "source_error": 0,

--- a/examples/synthetic/judgment-ledger-record.json
+++ b/examples/synthetic/judgment-ledger-record.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "0.1.0",
+  "judgment_id": "jdg-synthetic-r5-001",
+  "created_at": "2026-08-31T04:00:00Z",
+  "subject_refs": {
+    "event_ids": [
+      "evt-synthetic-r2-001"
+    ],
+    "claim_ids": [
+      "clm-synthetic-r2-001"
+    ],
+    "edge_ids": [
+      "edge-synthetic-001"
+    ],
+    "scenario_ids": [
+      "scn-synthetic-001"
+    ]
+  },
+  "initial_claim_grade": "B",
+  "event_priority": "P1",
+  "system_state_refs": [
+    "sdl-synthetic-r3-001"
+  ],
+  "current_finding": "Synthetic transmission hypothesis is plausible but not fully confirmed.",
+  "predicted_paths": [
+    {
+      "path_id": "path-synthetic-1",
+      "description": "Synthetic base path.",
+      "likelihood_band": "plausible"
+    },
+    {
+      "path_id": "path-synthetic-2",
+      "description": "Synthetic alternate path.",
+      "likelihood_band": "possible"
+    }
+  ],
+  "tail_risk": "Synthetic tail risk.",
+  "watch_signals": [
+    {
+      "signal_id": "watch-synthetic-1",
+      "description": "Synthetic downstream transmission observable.",
+      "role": "upgrade"
+    },
+    {
+      "signal_id": "watch-synthetic-2",
+      "description": "Synthetic falsification observable.",
+      "role": "falsification"
+    }
+  ],
+  "source_observation_ids": [
+    "sob-synthetic-001"
+  ],
+  "source_limitations": [
+    "Synthetic fixture only."
+  ],
+  "outcome_status": "unresolved",
+  "later_result": null,
+  "error_types": [],
+  "posterior_revision_ids": [],
+  "sensitivity": "public"
+}

--- a/examples/synthetic/judgment-ledger-record.json
+++ b/examples/synthetic/judgment-ledger-record.json
@@ -53,9 +53,5 @@
   "source_limitations": [
     "Synthetic fixture only."
   ],
-  "outcome_status": "unresolved",
-  "later_result": null,
-  "error_types": [],
-  "posterior_revision_ids": [],
   "sensitivity": "public"
 }

--- a/examples/synthetic/judgment-outcome-record.json
+++ b/examples/synthetic/judgment-outcome-record.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "0.1.0",
+  "outcome_id": "jot-synthetic-r5-001",
+  "judgment_id": "jdg-synthetic-r5-001",
+  "previous_outcome_id": null,
+  "evaluated_at": "2026-08-31T05:05:00Z",
+  "outcome_status": "unresolved",
+  "later_result": null,
+  "error_types": [],
+  "posterior_revision_ids": [
+    "prv-synthetic-r5-001"
+  ],
+  "sensitivity": "public"
+}

--- a/examples/synthetic/judgment-outcome-record.json
+++ b/examples/synthetic/judgment-outcome-record.json
@@ -4,9 +4,11 @@
   "judgment_id": "jdg-synthetic-r5-001",
   "previous_outcome_id": null,
   "evaluated_at": "2026-08-31T05:05:00Z",
-  "outcome_status": "unresolved",
-  "later_result": null,
-  "error_types": [],
+  "outcome_status": "resolved",
+  "later_result": "Synthetic narrow claim was confirmed by later evidence.",
+  "error_types": [
+    "none"
+  ],
   "posterior_revision_ids": [
     "prv-synthetic-r5-001"
   ],

--- a/examples/synthetic/posterior-revision.json
+++ b/examples/synthetic/posterior-revision.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "0.1.0",
+  "revision_id": "prv-synthetic-r5-001",
+  "judgment_id": "jdg-synthetic-r5-001",
+  "claim_id": "clm-synthetic-r2-001",
+  "new_evidence_ids": [
+    "evd-synthetic-001"
+  ],
+  "refuting_evidence_ids": [],
+  "source_reputation_refs": [
+    "rep-synthetic-wire-diplomacy-behavior"
+  ],
+  "counterevidence_assessment_ids": [
+    "hya-synthetic-r3-001"
+  ],
+  "prior_state": {
+    "claim_grade": "B",
+    "finding_summary": "Synthetic hypothesis remained unconfirmed."
+  },
+  "posterior_state": {
+    "claim_grade": "A",
+    "finding_summary": "Synthetic primary evidence confirmed the narrow factual claim."
+  },
+  "direction": "strengthen",
+  "rationale": [
+    "Synthetic primary evidence became available.",
+    "Counterevidence did not trigger falsification."
+  ],
+  "created_at": "2026-08-31T05:00:00Z",
+  "sensitivity": "public"
+}

--- a/schemas/alert-history-record.schema.json
+++ b/schemas/alert-history-record.schema.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/alert-history-record.schema.json",
+  "title": "Alert History Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "alert_history_id",
+    "candidate_id",
+    "decision_id",
+    "delivery_mode",
+    "outcome",
+    "trigger_codes",
+    "suppression_codes",
+    "state_signature",
+    "decided_at",
+    "recorded_at",
+    "related_prior_alert_id",
+    "later_evaluation",
+    "transport_status",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "alert_history_id": {
+      "type": "string",
+      "pattern": "^ahs-[A-Za-z0-9._-]+$"
+    },
+    "candidate_id": {
+      "type": "string",
+      "pattern": "^ogc-[A-Za-z0-9._-]+$"
+    },
+    "decision_id": {
+      "type": "string",
+      "pattern": "^ogd-[A-Za-z0-9._-]+$"
+    },
+    "delivery_mode": {
+      "enum": [
+        "scheduled_brief",
+        "interrupt_alert"
+      ]
+    },
+    "outcome": {
+      "enum": [
+        "EMIT",
+        "SUPPRESS"
+      ]
+    },
+    "trigger_codes": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "SCHEDULED_MATERIAL_ITEM",
+          "P0_MATERIAL",
+          "TRIGGER_A_RESONANCE",
+          "TRIGGER_B_MAJOR_EVENT",
+          "TRIGGER_C_NEW_STRONG_EDGE",
+          "HYPOTHESIS_FALSIFIED",
+          "LEAD_TIME_COMPRESSION",
+          "GLOBAL_STAGE_CHANGE",
+          "PERSONAL_ACTION_CHANGE"
+        ]
+      }
+    },
+    "suppression_codes": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "P3_SILENT",
+          "NO_SUBSTANTIVE_CHANGE",
+          "DUPLICATE_STATE",
+          "NO_TRIGGER",
+          "COOLDOWN",
+          "HYSTERESIS"
+        ]
+      }
+    },
+    "state_signature": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "decided_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "recorded_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "related_prior_alert_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^ahs-[A-Za-z0-9._-]+$"
+    },
+    "later_evaluation": {
+      "enum": [
+        "unreviewed",
+        "appropriate",
+        "false_positive",
+        "missed_signal",
+        "too_early",
+        "too_late",
+        "unknown"
+      ]
+    },
+    "transport_status": {
+      "enum": [
+        "not_applicable",
+        "not_sent",
+        "sent",
+        "unknown"
+      ]
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/judgment-calibration-summary.schema.json
+++ b/schemas/judgment-calibration-summary.schema.json
@@ -8,6 +8,7 @@
     "schema_version",
     "summary_id",
     "judgment_ids",
+    "outcome_ids",
     "total_count",
     "resolved_count",
     "partially_resolved_count",
@@ -122,6 +123,14 @@
         "confidential",
         "restricted"
       ]
+    },
+    "outcome_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^jot-[A-Za-z0-9._-]+$"
+      }
     }
   }
 }

--- a/schemas/judgment-calibration-summary.schema.json
+++ b/schemas/judgment-calibration-summary.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/judgment-calibration-summary.schema.json",
+  "title": "Judgment Calibration Summary",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "summary_id",
+    "judgment_ids",
+    "total_count",
+    "resolved_count",
+    "partially_resolved_count",
+    "unresolved_count",
+    "error_type_counts",
+    "generated_at",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "summary_id": {
+      "type": "string",
+      "pattern": "^jcs-[A-Za-z0-9._-]+$"
+    },
+    "judgment_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^jdg-[A-Za-z0-9._-]+$"
+      }
+    },
+    "total_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "resolved_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "partially_resolved_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "unresolved_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "error_type_counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "none",
+        "source_error",
+        "overreaction",
+        "underreaction",
+        "timing_error",
+        "omitted_variable",
+        "correlation_as_causality",
+        "rhetoric_overweight",
+        "technology_maturity_overestimate",
+        "execution_delay",
+        "unknown"
+      ],
+      "properties": {
+        "none": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "source_error": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "overreaction": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "underreaction": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "timing_error": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "omitted_variable": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "correlation_as_causality": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "rhetoric_overweight": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "technology_maturity_overestimate": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "execution_delay": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unknown": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/judgment-ledger-record.schema.json
+++ b/schemas/judgment-ledger-record.schema.json
@@ -18,10 +18,6 @@
     "watch_signals",
     "source_observation_ids",
     "source_limitations",
-    "outcome_status",
-    "later_result",
-    "error_types",
-    "posterior_revision_ids",
     "sensitivity"
   ],
   "properties": {
@@ -199,46 +195,6 @@
       "items": {
         "type": "string",
         "minLength": 1
-      }
-    },
-    "outcome_status": {
-      "enum": [
-        "unresolved",
-        "partially_resolved",
-        "resolved"
-      ]
-    },
-    "later_result": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "error_types": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "enum": [
-          "none",
-          "source_error",
-          "overreaction",
-          "underreaction",
-          "timing_error",
-          "omitted_variable",
-          "correlation_as_causality",
-          "rhetoric_overweight",
-          "technology_maturity_overestimate",
-          "execution_delay",
-          "unknown"
-        ]
-      }
-    },
-    "posterior_revision_ids": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "type": "string",
-        "pattern": "^prv-[A-Za-z0-9._-]+$"
       }
     },
     "sensitivity": {

--- a/schemas/judgment-ledger-record.schema.json
+++ b/schemas/judgment-ledger-record.schema.json
@@ -1,0 +1,253 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/judgment-ledger-record.schema.json",
+  "title": "Judgment Ledger Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "judgment_id",
+    "created_at",
+    "subject_refs",
+    "initial_claim_grade",
+    "event_priority",
+    "system_state_refs",
+    "current_finding",
+    "predicted_paths",
+    "tail_risk",
+    "watch_signals",
+    "source_observation_ids",
+    "source_limitations",
+    "outcome_status",
+    "later_result",
+    "error_types",
+    "posterior_revision_ids",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "judgment_id": {
+      "type": "string",
+      "pattern": "^jdg-[A-Za-z0-9._-]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "subject_refs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event_ids",
+        "claim_ids",
+        "edge_ids",
+        "scenario_ids"
+      ],
+      "properties": {
+        "event_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^evt-[A-Za-z0-9._-]+$"
+          }
+        },
+        "claim_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^clm-[A-Za-z0-9._-]+$"
+          }
+        },
+        "edge_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^edge-[A-Za-z0-9._-]+$"
+          }
+        },
+        "scenario_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^scn-[A-Za-z0-9._-]+$"
+          }
+        }
+      }
+    },
+    "initial_claim_grade": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "A",
+        "B",
+        "C",
+        "D",
+        null
+      ]
+    },
+    "event_priority": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "P0",
+        "P1",
+        "P2",
+        "P3",
+        null
+      ]
+    },
+    "system_state_refs": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "current_finding": {
+      "type": "string",
+      "minLength": 1
+    },
+    "predicted_paths": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "path_id",
+          "description",
+          "likelihood_band"
+        ],
+        "properties": {
+          "path_id": {
+            "type": "string",
+            "pattern": "^path-[A-Za-z0-9._-]+$"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "likelihood_band": {
+            "enum": [
+              "remote",
+              "possible",
+              "plausible",
+              "likely",
+              "unknown"
+            ]
+          }
+        }
+      }
+    },
+    "tail_risk": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "watch_signals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "signal_id",
+          "description",
+          "role"
+        ],
+        "properties": {
+          "signal_id": {
+            "type": "string",
+            "pattern": "^watch-[A-Za-z0-9._-]+$"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "role": {
+            "enum": [
+              "upgrade",
+              "downgrade",
+              "falsification",
+              "timing",
+              "other"
+            ]
+          }
+        }
+      }
+    },
+    "source_observation_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^sob-[A-Za-z0-9._-]+$"
+      }
+    },
+    "source_limitations": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "outcome_status": {
+      "enum": [
+        "unresolved",
+        "partially_resolved",
+        "resolved"
+      ]
+    },
+    "later_result": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "error_types": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "none",
+          "source_error",
+          "overreaction",
+          "underreaction",
+          "timing_error",
+          "omitted_variable",
+          "correlation_as_causality",
+          "rhetoric_overweight",
+          "technology_maturity_overestimate",
+          "execution_delay",
+          "unknown"
+        ]
+      }
+    },
+    "posterior_revision_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^prv-[A-Za-z0-9._-]+$"
+      }
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/judgment-outcome-record.schema.json
+++ b/schemas/judgment-outcome-record.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/judgment-outcome-record.schema.json",
+  "title": "Judgment Outcome Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "outcome_id",
+    "judgment_id",
+    "previous_outcome_id",
+    "evaluated_at",
+    "outcome_status",
+    "later_result",
+    "error_types",
+    "posterior_revision_ids",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "outcome_id": {
+      "type": "string",
+      "pattern": "^jot-[A-Za-z0-9._-]+$"
+    },
+    "judgment_id": {
+      "type": "string",
+      "pattern": "^jdg-[A-Za-z0-9._-]+$"
+    },
+    "previous_outcome_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^jot-[A-Za-z0-9._-]+$"
+    },
+    "evaluated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "outcome_status": {
+      "enum": [
+        "unresolved",
+        "partially_resolved",
+        "resolved"
+      ]
+    },
+    "later_result": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "error_types": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "none",
+          "source_error",
+          "overreaction",
+          "underreaction",
+          "timing_error",
+          "omitted_variable",
+          "correlation_as_causality",
+          "rhetoric_overweight",
+          "technology_maturity_overestimate",
+          "execution_delay",
+          "unknown"
+        ]
+      }
+    },
+    "posterior_revision_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^prv-[A-Za-z0-9._-]+$"
+      }
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/posterior-revision.schema.json
+++ b/schemas/posterior-revision.schema.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/posterior-revision.schema.json",
+  "title": "Posterior Revision",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "revision_id",
+    "judgment_id",
+    "claim_id",
+    "new_evidence_ids",
+    "refuting_evidence_ids",
+    "source_reputation_refs",
+    "counterevidence_assessment_ids",
+    "prior_state",
+    "posterior_state",
+    "direction",
+    "rationale",
+    "created_at",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "revision_id": {
+      "type": "string",
+      "pattern": "^prv-[A-Za-z0-9._-]+$"
+    },
+    "judgment_id": {
+      "type": "string",
+      "pattern": "^jdg-[A-Za-z0-9._-]+$"
+    },
+    "claim_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^clm-[A-Za-z0-9._-]+$"
+    },
+    "new_evidence_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^evd-[A-Za-z0-9._-]+$"
+      }
+    },
+    "refuting_evidence_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^evd-[A-Za-z0-9._-]+$"
+      }
+    },
+    "source_reputation_refs": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^rep-[A-Za-z0-9._-]+$"
+      }
+    },
+    "counterevidence_assessment_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^hya-[A-Za-z0-9._-]+$"
+      }
+    },
+    "prior_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "claim_grade",
+        "finding_summary"
+      ],
+      "properties": {
+        "claim_grade": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "A",
+            "B",
+            "C",
+            "D",
+            null
+          ]
+        },
+        "finding_summary": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "posterior_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "claim_grade",
+        "finding_summary"
+      ],
+      "properties": {
+        "claim_grade": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "A",
+            "B",
+            "C",
+            "D",
+            null
+          ]
+        },
+        "finding_summary": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "direction": {
+      "enum": [
+        "strengthen",
+        "weaken",
+        "unchanged",
+        "falsified",
+        "reclassified",
+        "unknown"
+      ]
+    },
+    "rationale": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/scripts/validate_schemas.py
+++ b/scripts/validate_schemas.py
@@ -40,6 +40,11 @@ PAIRS = {
     "intelligence_output_candidate": ("schemas/intelligence-output-candidate.schema.json", "examples/synthetic/intelligence-output-candidate.json"),
     "intelligence_output_gate_context": ("schemas/intelligence-output-gate-context.schema.json", "examples/synthetic/intelligence-output-gate-context.json"),
     "intelligence_output_decision": ("schemas/intelligence-output-decision.schema.json", "examples/synthetic/intelligence-output-decision.json"),
+    "judgment_ledger_record": ("schemas/judgment-ledger-record.schema.json", "examples/synthetic/judgment-ledger-record.json"),
+    "judgment_outcome_record": ("schemas/judgment-outcome-record.schema.json", "examples/synthetic/judgment-outcome-record.json"),
+    "posterior_revision": ("schemas/posterior-revision.schema.json", "examples/synthetic/posterior-revision.json"),
+    "alert_history_record": ("schemas/alert-history-record.schema.json", "examples/synthetic/alert-history-record.json"),
+    "judgment_calibration_summary": ("schemas/judgment-calibration-summary.schema.json", "examples/synthetic/judgment-calibration-summary.json"),
 }
 
 def load(path):
@@ -177,6 +182,38 @@ def semantic_errors(name, obj):
             errors.append("SUPPRESS decision requires a suppression code")
         if obj["next_eligible_at"] is not None and "COOLDOWN" not in obj["suppression_codes"]:
             errors.append("next_eligible_at is only valid for cooldown suppression")
+    elif name == "judgment_ledger_record":
+        refs = obj["subject_refs"]
+        if not any(refs.values()):
+            errors.append("judgment must reference at least one event/claim/edge/scenario")
+    elif name == "judgment_outcome_record":
+        if obj["outcome_status"] == "resolved" and not obj["later_result"]:
+            errors.append("resolved judgment outcome requires later_result")
+        if "none" in obj["error_types"] and len(obj["error_types"]) > 1:
+            errors.append("error_types=none cannot coexist with other errors")
+        if obj["previous_outcome_id"] == obj["outcome_id"]:
+            errors.append("previous_outcome_id cannot self-reference")
+    elif name == "posterior_revision":
+        if obj["direction"] == "falsified":
+            if not obj["refuting_evidence_ids"] and not obj["counterevidence_assessment_ids"]:
+                errors.append("falsified posterior requires refuting evidence or counterevidence assessment")
+    elif name == "alert_history_record":
+        if obj["outcome"] == "EMIT":
+            if not obj["trigger_codes"]:
+                errors.append("EMIT alert history requires trigger_codes")
+            if obj["suppression_codes"]:
+                errors.append("EMIT alert history cannot contain suppression_codes")
+        else:
+            if not obj["suppression_codes"]:
+                errors.append("SUPPRESS alert history requires suppression_codes")
+    elif name == "judgment_calibration_summary":
+        total = obj["total_count"]
+        if obj["resolved_count"] + obj["partially_resolved_count"] + obj["unresolved_count"] != total:
+            errors.append("calibration outcome counts must sum to total_count")
+        if len(obj["judgment_ids"]) != total:
+            errors.append("calibration must contain one latest judgment_id per total_count")
+        if len(obj["outcome_ids"]) != total:
+            errors.append("calibration must contain one selected outcome_id per total_count")
     elif name == "structural_delta":
         h_order = {"H0": 0, "H1": 1, "H2": 2, "H3": 3}
         c_order = {"C0": 0, "C1": 1, "C2": 2, "C3": 3}

--- a/src/psrro/__init__.py
+++ b/src/psrro/__init__.py
@@ -1,3 +1,8 @@
+from .intelligence_memory import (
+    JudgmentMemoryStore,
+    claim_grade_changed,
+    summarize_judgment_calibration,
+)
 from .intelligence_output import (
     decide_output_gate,
     output_state_signature,
@@ -35,6 +40,9 @@ from .quantification import (
 )
 
 __all__ = [
+    "JudgmentMemoryStore",
+    "claim_grade_changed",
+    "summarize_judgment_calibration",
     "decide_output_gate",
     "output_state_signature",
     "assess_costly_signal",

--- a/src/psrro/intelligence_memory.py
+++ b/src/psrro/intelligence_memory.py
@@ -1,0 +1,135 @@
+"""Phase 3R-05 append-only judgment memory.
+
+This module records judgments and revisions. It intentionally does not assign
+numeric meaning to Claim Grade A/B/C/D and does not mutate source reputation.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Mapping, Sequence
+
+SAFE_COMPONENT = re.compile(r"^[A-Za-z0-9._-]+$")
+ERROR_TYPES = (
+    "none",
+    "source_error",
+    "overreaction",
+    "underreaction",
+    "timing_error",
+    "omitted_variable",
+    "correlation_as_causality",
+    "rhetoric_overweight",
+    "technology_maturity_overestimate",
+    "execution_delay",
+    "unknown",
+)
+
+
+def _safe(value: str, label: str) -> str:
+    if not SAFE_COMPONENT.fullmatch(value) or value in {".", ".."}:
+        raise ValueError(f"unsafe {label}: {value!r}")
+    return value
+
+
+def _canonical_payload(obj: Mapping) -> str:
+    return json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _append_only_write(path: Path, obj: Mapping) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    new_payload = _canonical_payload(obj)
+    if path.exists():
+        existing = json.loads(path.read_text(encoding="utf-8"))
+        if _canonical_payload(existing) != new_payload:
+            raise ValueError(f"append-only record collision at {path}")
+        return path
+    path.write_text(
+        json.dumps(obj, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class JudgmentMemoryStore:
+    """Append-only reference store with idempotent replay."""
+
+    def __init__(self, root: str | Path):
+        self.root = Path(root)
+
+    def append_judgment(self, record: Mapping) -> Path:
+        jid = _safe(str(record["judgment_id"]), "judgment_id")
+        return _append_only_write(self.root / "judgments" / f"{jid}.json", record)
+
+    def get_judgment(self, judgment_id: str) -> dict:
+        jid = _safe(judgment_id, "judgment_id")
+        return _load(self.root / "judgments" / f"{jid}.json")
+
+    def append_revision(self, record: Mapping) -> Path:
+        rid = _safe(str(record["revision_id"]), "revision_id")
+        jid = _safe(str(record["judgment_id"]), "judgment_id")
+        return _append_only_write(
+            self.root / "revisions" / jid / f"{rid}.json",
+            record,
+        )
+
+    def get_revision(self, judgment_id: str, revision_id: str) -> dict:
+        jid = _safe(judgment_id, "judgment_id")
+        rid = _safe(revision_id, "revision_id")
+        return _load(self.root / "revisions" / jid / f"{rid}.json")
+
+    def append_alert_history(self, record: Mapping) -> Path:
+        aid = _safe(str(record["alert_history_id"]), "alert_history_id")
+        return _append_only_write(self.root / "alerts" / f"{aid}.json", record)
+
+    def get_alert_history(self, alert_history_id: str) -> dict:
+        aid = _safe(alert_history_id, "alert_history_id")
+        return _load(self.root / "alerts" / f"{aid}.json")
+
+
+def summarize_judgment_calibration(
+    judgments: Sequence[Mapping],
+    *,
+    summary_id: str = "jcs-derived",
+    generated_at: str = "1970-01-01T00:00:00Z",
+    sensitivity: str = "public",
+) -> dict:
+    """Count outcomes/errors without manufacturing one aggregate accuracy score."""
+    status_counts = {
+        "resolved": 0,
+        "partially_resolved": 0,
+        "unresolved": 0,
+    }
+    error_counts = {name: 0 for name in ERROR_TYPES}
+
+    ids = []
+    for judgment in judgments:
+        ids.append(judgment["judgment_id"])
+        status_counts[judgment["outcome_status"]] += 1
+        for error_type in judgment.get("error_types", []):
+            if error_type not in error_counts:
+                raise ValueError(f"unsupported error type: {error_type}")
+            error_counts[error_type] += 1
+
+    return {
+        "schema_version": "0.1.0",
+        "summary_id": summary_id,
+        "judgment_ids": sorted(set(ids)),
+        "total_count": len(judgments),
+        "resolved_count": status_counts["resolved"],
+        "partially_resolved_count": status_counts["partially_resolved"],
+        "unresolved_count": status_counts["unresolved"],
+        "error_type_counts": error_counts,
+        "generated_at": generated_at,
+        "sensitivity": sensitivity,
+    }
+
+
+def claim_grade_changed(prior_grade: str | None, posterior_grade: str | None) -> bool:
+    """Identity comparison only. No A/B/C/D numeric ordering exists here."""
+    return prior_grade != posterior_grade

--- a/src/psrro/intelligence_memory.py
+++ b/src/psrro/intelligence_memory.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import re
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Mapping, Sequence
 
@@ -54,6 +55,15 @@ def _append_only_write(path: Path, obj: Mapping) -> Path:
 
 def _load(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _parse_dt(value: str) -> datetime:
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        raise ValueError("datetime must be timezone-aware")
+    return dt.astimezone(timezone.utc)
 
 
 class JudgmentMemoryStore:
@@ -112,7 +122,19 @@ def summarize_judgment_calibration(
     generated_at: str = "1970-01-01T00:00:00Z",
     sensitivity: str = "public",
 ) -> dict:
-    """Count latest supplied outcome records without manufacturing one accuracy score."""
+    """Use the latest outcome per judgment; retain full history outside the summary."""
+    latest: dict[str, Mapping] = {}
+    latest_time: dict[str, datetime] = {}
+
+    for outcome in outcomes:
+        jid = outcome["judgment_id"]
+        evaluated = _parse_dt(outcome["evaluated_at"])
+        if jid not in latest or evaluated > latest_time[jid]:
+            latest[jid] = outcome
+            latest_time[jid] = evaluated
+        elif evaluated == latest_time[jid] and outcome["outcome_id"] != latest[jid]["outcome_id"]:
+            raise ValueError(f"ambiguous latest outcome timestamp for {jid}")
+
     status_counts = {
         "resolved": 0,
         "partially_resolved": 0,
@@ -120,9 +142,8 @@ def summarize_judgment_calibration(
     }
     error_counts = {name: 0 for name in ERROR_TYPES}
 
-    judgment_ids = []
-    for outcome in outcomes:
-        judgment_ids.append(outcome["judgment_id"])
+    selected = [latest[jid] for jid in sorted(latest)]
+    for outcome in selected:
         status_counts[outcome["outcome_status"]] += 1
         for error_type in outcome.get("error_types", []):
             if error_type not in error_counts:
@@ -132,8 +153,9 @@ def summarize_judgment_calibration(
     return {
         "schema_version": "0.1.0",
         "summary_id": summary_id,
-        "judgment_ids": sorted(set(judgment_ids)),
-        "total_count": len(outcomes),
+        "judgment_ids": [outcome["judgment_id"] for outcome in selected],
+        "outcome_ids": [outcome["outcome_id"] for outcome in selected],
+        "total_count": len(selected),
         "resolved_count": status_counts["resolved"],
         "partially_resolved_count": status_counts["partially_resolved"],
         "unresolved_count": status_counts["unresolved"],

--- a/src/psrro/intelligence_memory.py
+++ b/src/psrro/intelligence_memory.py
@@ -70,6 +70,19 @@ class JudgmentMemoryStore:
         jid = _safe(judgment_id, "judgment_id")
         return _load(self.root / "judgments" / f"{jid}.json")
 
+    def append_outcome(self, record: Mapping) -> Path:
+        oid = _safe(str(record["outcome_id"]), "outcome_id")
+        jid = _safe(str(record["judgment_id"]), "judgment_id")
+        return _append_only_write(
+            self.root / "outcomes" / jid / f"{oid}.json",
+            record,
+        )
+
+    def get_outcome(self, judgment_id: str, outcome_id: str) -> dict:
+        jid = _safe(judgment_id, "judgment_id")
+        oid = _safe(outcome_id, "outcome_id")
+        return _load(self.root / "outcomes" / jid / f"{oid}.json")
+
     def append_revision(self, record: Mapping) -> Path:
         rid = _safe(str(record["revision_id"]), "revision_id")
         jid = _safe(str(record["judgment_id"]), "judgment_id")
@@ -93,13 +106,13 @@ class JudgmentMemoryStore:
 
 
 def summarize_judgment_calibration(
-    judgments: Sequence[Mapping],
+    outcomes: Sequence[Mapping],
     *,
     summary_id: str = "jcs-derived",
     generated_at: str = "1970-01-01T00:00:00Z",
     sensitivity: str = "public",
 ) -> dict:
-    """Count outcomes/errors without manufacturing one aggregate accuracy score."""
+    """Count latest supplied outcome records without manufacturing one accuracy score."""
     status_counts = {
         "resolved": 0,
         "partially_resolved": 0,
@@ -107,11 +120,11 @@ def summarize_judgment_calibration(
     }
     error_counts = {name: 0 for name in ERROR_TYPES}
 
-    ids = []
-    for judgment in judgments:
-        ids.append(judgment["judgment_id"])
-        status_counts[judgment["outcome_status"]] += 1
-        for error_type in judgment.get("error_types", []):
+    judgment_ids = []
+    for outcome in outcomes:
+        judgment_ids.append(outcome["judgment_id"])
+        status_counts[outcome["outcome_status"]] += 1
+        for error_type in outcome.get("error_types", []):
             if error_type not in error_counts:
                 raise ValueError(f"unsupported error type: {error_type}")
             error_counts[error_type] += 1
@@ -119,8 +132,8 @@ def summarize_judgment_calibration(
     return {
         "schema_version": "0.1.0",
         "summary_id": summary_id,
-        "judgment_ids": sorted(set(ids)),
-        "total_count": len(judgments),
+        "judgment_ids": sorted(set(judgment_ids)),
+        "total_count": len(outcomes),
         "resolved_count": status_counts["resolved"],
         "partially_resolved_count": status_counts["partially_resolved"],
         "unresolved_count": status_counts["unresolved"],
@@ -128,7 +141,6 @@ def summarize_judgment_calibration(
         "generated_at": generated_at,
         "sensitivity": sensitivity,
     }
-
 
 def claim_grade_changed(prior_grade: str | None, posterior_grade: str | None) -> bool:
     """Identity comparison only. No A/B/C/D numeric ordering exists here."""

--- a/tests/test_intelligence_memory.py
+++ b/tests/test_intelligence_memory.py
@@ -16,10 +16,18 @@ def judgment(jid="jdg-1"):
     }
 
 
-def outcome(oid="jot-1", jid="jdg-1", status="unresolved", errors=None, later=None):
+def outcome(
+    oid="jot-1",
+    jid="jdg-1",
+    status="unresolved",
+    errors=None,
+    later=None,
+    evaluated_at="2026-08-31T00:00:00Z",
+):
     return {
         "outcome_id": oid,
         "judgment_id": jid,
+        "evaluated_at": evaluated_at,
         "outcome_status": status,
         "error_types": errors or [],
         "later_result": later,
@@ -122,14 +130,39 @@ class CalibrationTests(unittest.TestCase):
         self.assertEqual(result["error_type_counts"]["timing_error"], 1)
         self.assertNotIn("accuracy_score", result)
 
-    def test_duplicate_judgment_ids_remain_visible_as_multiple_outcome_observations(self):
+    def test_latest_outcome_per_judgment_is_used_for_current_calibration(self):
         rows = [
-            outcome("jot-1", "jdg-1", "unresolved", [], None),
-            outcome("jot-2", "jdg-1", "partially_resolved", ["unknown"], "new evidence"),
+            outcome(
+                "jot-1",
+                "jdg-1",
+                "unresolved",
+                [],
+                None,
+                "2026-08-31T00:00:00Z",
+            ),
+            outcome(
+                "jot-2",
+                "jdg-1",
+                "partially_resolved",
+                ["unknown"],
+                "new evidence",
+                "2026-08-31T01:00:00Z",
+            ),
         ]
         result = summarize_judgment_calibration(rows)
-        self.assertEqual(result["total_count"], 2)
+        self.assertEqual(result["total_count"], 1)
         self.assertEqual(result["judgment_ids"], ["jdg-1"])
+        self.assertEqual(result["outcome_ids"], ["jot-2"])
+        self.assertEqual(result["partially_resolved_count"], 1)
+        self.assertEqual(result["error_type_counts"]["unknown"], 1)
+
+    def test_equal_latest_timestamps_fail_closed(self):
+        rows = [
+            outcome("jot-1", "jdg-1", evaluated_at="2026-08-31T01:00:00Z"),
+            outcome("jot-2", "jdg-1", evaluated_at="2026-08-31T01:00:00Z"),
+        ]
+        with self.assertRaises(ValueError):
+            summarize_judgment_calibration(rows)
 
 
 if __name__ == "__main__":

--- a/tests/test_intelligence_memory.py
+++ b/tests/test_intelligence_memory.py
@@ -1,0 +1,105 @@
+import copy
+import tempfile
+import unittest
+
+from src.psrro.intelligence_memory import (
+    JudgmentMemoryStore,
+    claim_grade_changed,
+    summarize_judgment_calibration,
+)
+
+
+def judgment(jid="jdg-1", outcome="unresolved", errors=None):
+    return {
+        "judgment_id": jid,
+        "outcome_status": outcome,
+        "error_types": errors or [],
+        "current_finding": "synthetic",
+    }
+
+
+class AppendOnlyStoreTests(unittest.TestCase):
+    def test_idempotent_replay_is_allowed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgmentMemoryStore(tmp)
+            row = judgment()
+            store.append_judgment(row)
+            store.append_judgment(copy.deepcopy(row))
+            self.assertEqual(store.get_judgment("jdg-1"), row)
+
+    def test_same_id_with_changed_content_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgmentMemoryStore(tmp)
+            store.append_judgment(judgment())
+            changed = judgment()
+            changed["current_finding"] = "rewritten history"
+            with self.assertRaises(ValueError):
+                store.append_judgment(changed)
+
+    def test_revision_is_append_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgmentMemoryStore(tmp)
+            rev = {"revision_id": "prv-1", "judgment_id": "jdg-1", "value": 1}
+            store.append_revision(rev)
+            with self.assertRaises(ValueError):
+                store.append_revision({"revision_id": "prv-1", "judgment_id": "jdg-1", "value": 2})
+            self.assertEqual(store.get_revision("jdg-1", "prv-1"), rev)
+
+    def test_suppressed_alert_is_still_remembered(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgmentMemoryStore(tmp)
+            row = {
+                "alert_history_id": "ahs-1",
+                "outcome": "SUPPRESS",
+                "decision_id": "ogd-1",
+            }
+            store.append_alert_history(row)
+            self.assertEqual(store.get_alert_history("ahs-1"), row)
+
+    def test_unsafe_identifier_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgmentMemoryStore(tmp)
+            with self.assertRaises(ValueError):
+                store.append_judgment({"judgment_id": "../escape"})
+
+
+class ClaimGradeTests(unittest.TestCase):
+    def test_grade_function_only_checks_identity(self):
+        self.assertTrue(claim_grade_changed("B", "A"))
+        self.assertTrue(claim_grade_changed("D", "C"))
+        self.assertFalse(claim_grade_changed("D", "D"))
+
+    def test_d_is_not_numeric_lowest_grade(self):
+        # No function exists to order grades; D may mean analysis/opinion/prediction.
+        self.assertTrue(claim_grade_changed("D", "A"))
+
+
+class CalibrationTests(unittest.TestCase):
+    def test_counts_resolved_and_error_types(self):
+        rows = [
+            judgment("jdg-1", "resolved", ["none"]),
+            judgment("jdg-2", "resolved", ["overreaction", "timing_error"]),
+            judgment("jdg-3", "unresolved", []),
+            judgment("jdg-4", "partially_resolved", ["omitted_variable"]),
+        ]
+        result = summarize_judgment_calibration(rows)
+        self.assertEqual(result["total_count"], 4)
+        self.assertEqual(result["resolved_count"], 2)
+        self.assertEqual(result["unresolved_count"], 1)
+        self.assertEqual(result["partially_resolved_count"], 1)
+        self.assertEqual(result["error_type_counts"]["overreaction"], 1)
+        self.assertEqual(result["error_type_counts"]["timing_error"], 1)
+        self.assertNotIn("accuracy_score", result)
+
+    def test_duplicate_ids_do_not_change_total_observation_count(self):
+        rows = [
+            judgment("jdg-1", "resolved", ["none"]),
+            judgment("jdg-1", "resolved", ["none"]),
+        ]
+        result = summarize_judgment_calibration(rows)
+        self.assertEqual(result["total_count"], 2)
+        self.assertEqual(result["judgment_ids"], ["jdg-1"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_intelligence_memory.py
+++ b/tests/test_intelligence_memory.py
@@ -1,6 +1,8 @@
 import copy
+import json
 import tempfile
 import unittest
+from pathlib import Path
 
 from src.psrro.intelligence_memory import (
     JudgmentMemoryStore,
@@ -32,6 +34,26 @@ def outcome(
         "error_types": errors or [],
         "later_result": later,
     }
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ExampleContractTests(unittest.TestCase):
+    def test_synthetic_outcome_recomputes_calibration_fixture(self):
+        outcome_obj = json.loads(
+            (ROOT / "examples" / "synthetic" / "judgment-outcome-record.json").read_text(encoding="utf-8")
+        )
+        expected = json.loads(
+            (ROOT / "examples" / "synthetic" / "judgment-calibration-summary.json").read_text(encoding="utf-8")
+        )
+        actual = summarize_judgment_calibration(
+            [outcome_obj],
+            summary_id=expected["summary_id"],
+            generated_at=expected["generated_at"],
+            sensitivity=expected["sensitivity"],
+        )
+        self.assertEqual(actual, expected)
 
 
 class AppendOnlyStoreTests(unittest.TestCase):

--- a/tests/test_intelligence_memory.py
+++ b/tests/test_intelligence_memory.py
@@ -9,17 +9,25 @@ from src.psrro.intelligence_memory import (
 )
 
 
-def judgment(jid="jdg-1", outcome="unresolved", errors=None):
+def judgment(jid="jdg-1"):
     return {
         "judgment_id": jid,
-        "outcome_status": outcome,
-        "error_types": errors or [],
         "current_finding": "synthetic",
     }
 
 
+def outcome(oid="jot-1", jid="jdg-1", status="unresolved", errors=None, later=None):
+    return {
+        "outcome_id": oid,
+        "judgment_id": jid,
+        "outcome_status": status,
+        "error_types": errors or [],
+        "later_result": later,
+    }
+
+
 class AppendOnlyStoreTests(unittest.TestCase):
-    def test_idempotent_replay_is_allowed(self):
+    def test_idempotent_judgment_replay_is_allowed(self):
         with tempfile.TemporaryDirectory() as tmp:
             store = JudgmentMemoryStore(tmp)
             row = judgment()
@@ -27,7 +35,7 @@ class AppendOnlyStoreTests(unittest.TestCase):
             store.append_judgment(copy.deepcopy(row))
             self.assertEqual(store.get_judgment("jdg-1"), row)
 
-    def test_same_id_with_changed_content_is_rejected(self):
+    def test_original_judgment_cannot_be_rewritten(self):
         with tempfile.TemporaryDirectory() as tmp:
             store = JudgmentMemoryStore(tmp)
             store.append_judgment(judgment())
@@ -35,6 +43,29 @@ class AppendOnlyStoreTests(unittest.TestCase):
             changed["current_finding"] = "rewritten history"
             with self.assertRaises(ValueError):
                 store.append_judgment(changed)
+
+    def test_later_result_is_appended_as_outcome_not_judgment_mutation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgmentMemoryStore(tmp)
+            j = judgment()
+            o = outcome(
+                status="resolved",
+                errors=["none"],
+                later="synthetic result confirmed",
+            )
+            store.append_judgment(j)
+            store.append_outcome(o)
+            self.assertEqual(store.get_judgment("jdg-1"), j)
+            self.assertEqual(store.get_outcome("jdg-1", "jot-1"), o)
+
+    def test_outcome_is_append_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JudgmentMemoryStore(tmp)
+            store.append_outcome(outcome())
+            changed = outcome()
+            changed["outcome_status"] = "resolved"
+            with self.assertRaises(ValueError):
+                store.append_outcome(changed)
 
     def test_revision_is_append_only(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -75,12 +106,12 @@ class ClaimGradeTests(unittest.TestCase):
 
 
 class CalibrationTests(unittest.TestCase):
-    def test_counts_resolved_and_error_types(self):
+    def test_counts_latest_supplied_outcomes_and_error_types(self):
         rows = [
-            judgment("jdg-1", "resolved", ["none"]),
-            judgment("jdg-2", "resolved", ["overreaction", "timing_error"]),
-            judgment("jdg-3", "unresolved", []),
-            judgment("jdg-4", "partially_resolved", ["omitted_variable"]),
+            outcome("jot-1", "jdg-1", "resolved", ["none"], "confirmed"),
+            outcome("jot-2", "jdg-2", "resolved", ["overreaction", "timing_error"], "wrong timing"),
+            outcome("jot-3", "jdg-3", "unresolved", [], None),
+            outcome("jot-4", "jdg-4", "partially_resolved", ["omitted_variable"], "partial"),
         ]
         result = summarize_judgment_calibration(rows)
         self.assertEqual(result["total_count"], 4)
@@ -91,10 +122,10 @@ class CalibrationTests(unittest.TestCase):
         self.assertEqual(result["error_type_counts"]["timing_error"], 1)
         self.assertNotIn("accuracy_score", result)
 
-    def test_duplicate_ids_do_not_change_total_observation_count(self):
+    def test_duplicate_judgment_ids_remain_visible_as_multiple_outcome_observations(self):
         rows = [
-            judgment("jdg-1", "resolved", ["none"]),
-            judgment("jdg-1", "resolved", ["none"]),
+            outcome("jot-1", "jdg-1", "unresolved", [], None),
+            outcome("jot-2", "jdg-1", "partially_resolved", ["unknown"], "new evidence"),
         ]
         result = summarize_judgment_calibration(rows)
         self.assertEqual(result["total_count"], 2)


### PR DESCRIPTION
Closes #32

## Implements

- immutable Judgment Ledger Record
- append-only Judgment Outcome Record
- append-only Posterior Revision
- append-only Alert History
- current Judgment Calibration Summary from latest outcome per judgment
- append-only/idempotent JudgmentMemoryStore
- semantic Claim Grade A-D handling without numeric ordering
- synthetic fixture round-trip for outcome -> calibration
- R4 complete / R5 current project-state updates

## Key design correction

V0.3 later_result / error_type / posterior_update semantics are preserved without mutating the original judgment:

Original Judgment
→ append Outcome(s)
→ append Posterior Revision(s)

This prevents hindsight rewriting.

## Invariants

- same ID + changed content is rejected
- exact replay is idempotent
- latest Outcome per Judgment drives current calibration
- all historical Outcomes remain available for replay
- resolved outcome requires later_result
- error_type=none cannot coexist with other errors
- falsified Posterior requires refuting evidence/counterevidence
- Claim Grade D is not treated as numerically below A/B/C
- suppressed R4 decisions are remembered
- no aggregate accuracy score
- no source-score mutation

## Non-goals

No automatic grade promotion, hidden Bayesian score, notification transport, crawler/scheduler or private operational data.
