### PR TITLE
Phase 3R-06: Chain Watch v0.1

### DIFF
--- a/chains/climate-food-energy-inflation-ai.json
+++ b/chains/climate-food-energy-inflation-ai.json
@@ -1,0 +1,146 @@
+{
+  "schema_version": "0.1.0",
+  "chain_id": "chn-climate-food-energy-inflation-ai-v0.1",
+  "title": "Climate → Food/Energy → Inflation → Fed → UST/Financial Conditions → AI Capital Cycle",
+  "purpose": "Track whether climate/resource pressure is becoming a validated multi-link financial/technology transmission chain.",
+  "nodes": [
+    {
+      "node_id": "chnode-climate-el-nino",
+      "label": "Climate / El Niño",
+      "description": "ENSO intensity, climate anomalies and associated physical constraints.",
+      "observation_domains": [
+        "climate",
+        "natural_disaster"
+      ],
+      "risk_variables": [
+        "B"
+      ]
+    },
+    {
+      "node_id": "chnode-food-energy-pressure",
+      "label": "Food & Energy Pressure",
+      "description": "Food-price and energy-price/resource stress potentially linked to climate/resource constraints.",
+      "observation_domains": [
+        "food",
+        "energy"
+      ],
+      "risk_variables": [
+        "B"
+      ]
+    },
+    {
+      "node_id": "chnode-inflation-expectations",
+      "label": "Inflation / Inflation Expectations",
+      "description": "Observed and expected inflation response to food/energy pressure.",
+      "observation_domains": [
+        "rates",
+        "financial_markets"
+      ],
+      "risk_variables": [
+        "C"
+      ]
+    },
+    {
+      "node_id": "chnode-fed-policy",
+      "label": "Fed / Monetary Policy",
+      "description": "Federal Reserve reaction function and policy-path repricing.",
+      "observation_domains": [
+        "rates",
+        "macro"
+      ],
+      "risk_variables": [
+        "C"
+      ]
+    },
+    {
+      "node_id": "chnode-ust-financial-fiscal",
+      "label": "UST Long End / Financial Conditions / Fiscal Pressure",
+      "description": "10Y/30Y Treasury yields, term premium, financing conditions and fiscal-duration pressure.",
+      "observation_domains": [
+        "rates",
+        "sovereign_debt",
+        "financial_markets"
+      ],
+      "risk_variables": [
+        "C"
+      ]
+    },
+    {
+      "node_id": "chnode-ai-capex-valuation-financing",
+      "label": "AI CapEx / Tech Valuation / Financing Stress",
+      "description": "AI infrastructure spending, financing conditions and technology-asset valuation sensitivity.",
+      "observation_domains": [
+        "ai_capex",
+        "technology_valuation",
+        "financing"
+      ],
+      "risk_variables": [
+        "D"
+      ]
+    }
+  ],
+  "links": [
+    {
+      "link_id": "chlink-climate-to-food-energy",
+      "source_node_id": "chnode-climate-el-nino",
+      "target_node_id": "chnode-food-energy-pressure",
+      "mechanism": "Climate anomalies affect agricultural output, hydropower/resource availability and selected energy/food markets.",
+      "required": true,
+      "expected_latency_days": {
+        "min": 0,
+        "max": 180
+      },
+      "persistence_note": "Impact is geography-, crop-, season- and energy-system-specific; broad global transmission is not automatic."
+    },
+    {
+      "link_id": "chlink-food-energy-to-inflation",
+      "source_node_id": "chnode-food-energy-pressure",
+      "target_node_id": "chnode-inflation-expectations",
+      "mechanism": "Food and energy cost pressure transmits into headline inflation and may affect inflation expectations.",
+      "required": true,
+      "expected_latency_days": {
+        "min": 0,
+        "max": 120
+      },
+      "persistence_note": "Second-round/core inflation effects require separate evidence."
+    },
+    {
+      "link_id": "chlink-inflation-to-fed",
+      "source_node_id": "chnode-inflation-expectations",
+      "target_node_id": "chnode-fed-policy",
+      "mechanism": "Persistent inflation risk changes the Federal Reserve reaction function and expected policy path.",
+      "required": true,
+      "expected_latency_days": {
+        "min": 0,
+        "max": 180
+      },
+      "persistence_note": "Policy response also depends on labor markets, growth and financial stability."
+    },
+    {
+      "link_id": "chlink-fed-to-ust-financial-fiscal",
+      "source_node_id": "chnode-fed-policy",
+      "target_node_id": "chnode-ust-financial-fiscal",
+      "mechanism": "Policy expectations interact with term premium, Treasury supply and fiscal duration to alter long-end yields and financial conditions.",
+      "required": true,
+      "expected_latency_days": {
+        "min": 0,
+        "max": 180
+      },
+      "persistence_note": "Long-end yields are not a mechanical function of the policy rate; fiscal/term-premium drivers must remain explicit."
+    },
+    {
+      "link_id": "chlink-ust-financial-to-ai-capex",
+      "source_node_id": "chnode-ust-financial-fiscal",
+      "target_node_id": "chnode-ai-capex-valuation-financing",
+      "mechanism": "Higher long-duration financing costs and tighter credit conditions raise hurdle rates for AI infrastructure and compress rate-sensitive technology valuations.",
+      "required": true,
+      "expected_latency_days": {
+        "min": 0,
+        "max": 365
+      },
+      "persistence_note": "Strong earnings/monetization or strategic financing can offset rate pressure; CapEx reversal requires direct evidence."
+    }
+  ],
+  "created_at": "2026-08-31T06:00:00Z",
+  "sensitivity": "public"
+}

--- a/docs/CHAIN-WATCH.md
+++ b/docs/CHAIN-WATCH.md
@@ -55,7 +55,8 @@ It also stores:
 For Chain Watch v0.1, a link counts as connected transmission only when:
 
 - `H2` or `H3`; and
-- at least one explicit `causality` evidence item exists; and
+- at least one explicit `causality` evidence item exists;
+- at least one supporting Evidence reference is attached; and
 - the link is not falsified.
 
 Therefore:
@@ -86,9 +87,13 @@ Every required ordered link is supported.
 A previously BUILDING/TRANSMITTING chain is losing support and weakening dominates, without a required link being formally falsified.
 
 ### BROKEN
-At least one **required** link is Hx.
+At least one required link is Hx.
 
-Auxiliary/optional links may be tracked without automatically breaking the canonical required path.
+### v0.1 linear-chain constraint
+
+The canonical v0.1 Chain Watch is a single ordered linear path. Every link in that path is required.
+
+Branching, alternative mechanisms and auxiliary links are deliberately deferred to a future schema version rather than pretending a skipped middle link still forms a continuous path.
 
 ## 5. Longest contiguous supported path
 

--- a/docs/CHAIN-WATCH.md
+++ b/docs/CHAIN-WATCH.md
@@ -86,7 +86,9 @@ Every required ordered link is supported.
 A previously BUILDING/TRANSMITTING chain is losing support and weakening dominates, without a required link being formally falsified.
 
 ### BROKEN
-At least one required link is Hx.
+At least one **required** link is Hx.
+
+Auxiliary/optional links may be tracked without automatically breaking the canonical required path.
 
 ## 5. Longest contiguous supported path
 
@@ -111,6 +113,12 @@ R6 does not output:
 - a new global danger index.
 
 It reports structure.
+
+Snapshots therefore expose both:
+- total link count;
+- required link count;
+- all falsified links;
+- falsified required links.
 
 ## 7. Relationship to R4
 

--- a/docs/CHAIN-WATCH.md
+++ b/docs/CHAIN-WATCH.md
@@ -1,0 +1,148 @@
+# Chain Watch — Phase 3R-06 v0.1
+
+## Purpose
+
+Chain Watch answers:
+
+> Are the links in a hypothesized systemic transmission chain actually becoming connected?
+
+It does not infer a full causal chain from simultaneous headlines.
+
+## First canonical chain
+
+`Climate / El Niño`
+→ `Food & Energy Pressure`
+→ `Inflation / Inflation Expectations`
+→ `Fed / Monetary Policy`
+→ `UST 10Y / 30Y + Financial Conditions / Fiscal Pressure`
+→ `AI CapEx / Tech Valuation / Financing Stress`
+
+This is a watch hypothesis, not a declared causal fact.
+
+## 1. Chain Definition
+
+A Chain Definition stores:
+- ordered nodes;
+- ordered directed links;
+- mechanism per link;
+- expected latency where useful;
+- persistence notes;
+- observation domains;
+- Risk Variable mapping.
+
+Order matters.
+
+## 2. Link Assessment
+
+Every directed link stores distinct epistemic counts:
+
+- Fact
+- Forecast
+- Correlation
+- Causality
+- Counterevidence
+
+It also stores:
+- H0/H1/H2/H3/Hx;
+- direction;
+- Material Delta;
+- supporting/refuting evidence;
+- hypothesis/counterevidence refs;
+- common-cause refs.
+
+## 3. Causal support rule
+
+For Chain Watch v0.1, a link counts as connected transmission only when:
+
+- `H2` or `H3`; and
+- at least one explicit `causality` evidence item exists; and
+- the link is not falsified.
+
+Therefore:
+
+- Forecast-only H2 does not count.
+- Correlation-only H2 does not count.
+- A downstream fact does not automatically validate upstream causality.
+
+This is deliberately conservative.
+
+## 4. Chain state
+
+Chain state is descriptive and separate from Global Stage I-IV.
+
+### UNKNOWN
+Insufficient connected causal links.
+
+### FRAGMENTED
+At least one supported link exists, but supported links do not yet create a multi-link contiguous path.
+
+### BUILDING
+At least two contiguous required links are supported, but the full chain is incomplete.
+
+### TRANSMITTING
+Every required ordered link is supported.
+
+### RELAXING
+A previously BUILDING/TRANSMITTING chain is losing support and weakening dominates, without a required link being formally falsified.
+
+### BROKEN
+At least one required link is Hx.
+
+## 5. Longest contiguous supported path
+
+This is more informative than raw supported-link count.
+
+Example:
+
+`L1 supported, L2 unsupported, L3 supported`
+
+has:
+- supported count = 2;
+- longest contiguous path = 1;
+- state = FRAGMENTED.
+
+It is not a connected three-stage transmission.
+
+## 6. No chain score
+
+R6 does not output:
+- 73/100 risk;
+- 82% chain certainty;
+- a new global danger index.
+
+It reports structure.
+
+## 7. Relationship to R4
+
+R6 does not notify.
+
+A material Chain Watch state change may later become an R4 candidate:
+- BUILDING → TRANSMITTING;
+- new link H3;
+- required link → Hx;
+- major Lead Time compression.
+
+The output gate remains authoritative for interruption decisions.
+
+## 8. Relationship to R5
+
+Chain Watch snapshots and link assessments can be referenced by Judgment Ledger entries.
+
+That makes it possible to record:
+- when the chain was believed to be BUILDING;
+- which links were still missing;
+- what later evidence confirmed/falsified them.
+
+## 9. Anti-doom discipline
+
+The chain may weaken.
+
+The chain may break.
+
+A forecast may fail.
+
+Counterevidence is not an inconvenience; it is part of the data model.
+
+A useful Chain Watch must be equally capable of saying:
+
+> the hypothesized resonance is not closing.

--- a/docs/PROJECT-STATE.md
+++ b/docs/PROJECT-STATE.md
@@ -108,9 +108,9 @@ Phase 3R-00 and 3R-00A are complete.
 
 The canonical operational baseline is now the reconciled China Intelligence / Physical AI / Global Risk Resonance V0.3 specification. Phase 3R is explicitly an engineering upgrade around that working logic, not a redesign.
 
-R1 Source / Evidence Persistence, R2 Event / Claim State, R3 Behavior / Counterevidence / Structural Delta, and R4 Precision Alert Gate are COMPLETE.
+R1 Source / Evidence Persistence, R2 Event / Claim State, R3 Behavior / Counterevidence / Structural Delta, R4 Precision Alert Gate, and R5 Judgment Memory / Posterior Learning are COMPLETE.
 
-Current node: **R5 — Judgment Memory / Posterior Learning**.
+Current node: **R6 — Chain Watch**.
 
 Priority sequence:
 - Source Registry + Source Reputation Ledger;
@@ -119,8 +119,8 @@ Priority sequence:
 - Material Change and event fingerprints;
 - Behavior/System structural deltas — complete;
 - alert suppression/hysteresis — complete;
-- Judgment Ledger / posterior learning — current;
-- first Chain Watch: climate→food/energy→inflation→Fed→UST/financial conditions→AI CapEx/valuation.
+- Judgment Ledger / posterior learning — complete;
+- first Chain Watch — current: climate→food/energy→inflation→Fed→UST/financial conditions→AI CapEx/valuation.
 
 Namespace rule:
 - `Claim Grade A-D` = epistemic confidence;

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -87,17 +87,19 @@ Separate private operational-state layer established, pinned to public method ve
 - [x] "no substantive change = no notification"
 - [x] scheduled brief vs interrupt alert separation
 
-#### R5 — Judgment Memory / Learning — CURRENT
-- [~] immutable Judgment Ledger
-- [~] append-only Judgment Outcome history
-- [~] Alert History
-- [~] Posterior Revision
-- [~] source + judgment calibration
+#### R5 — Judgment Memory / Learning — COMPLETE
+- [x] immutable Judgment Ledger
+- [x] append-only Judgment Outcome history
+- [x] Alert History
+- [x] Posterior Revision
+- [x] source + judgment calibration
 
-#### R6 — Chain Watch
-- [ ] climate→food/energy→inflation→Fed→UST/financial conditions→AI CapEx/valuation
-- [ ] chain-state persistence
-- [ ] fact / forecast / correlation / causality / counterevidence per link
+#### R6 — Chain Watch — CURRENT
+- [~] climate→food/energy→inflation→Fed→UST/financial conditions→AI CapEx/valuation
+- [~] chain-state persistence
+- [~] fact / forecast / correlation / causality / counterevidence per link
+- [~] contiguous supported-path detection
+- [~] TRANSMITTING / BUILDING / FRAGMENTED / RELAXING / BROKEN semantics
 
 #### R7 — Replay / Red Team
 - [ ] Synthetic replay tests for duplicate, worsening, improvement, falsification

--- a/examples/synthetic/chain-link-assessment.json
+++ b/examples/synthetic/chain-link-assessment.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "0.1.0",
+  "assessment_id": "cla-synthetic-r6-001",
+  "chain_id": "chn-climate-food-energy-inflation-ai-v0.1",
+  "link_id": "chlink-food-energy-to-inflation",
+  "source_node_id": "chnode-food-energy-pressure",
+  "target_node_id": "chnode-inflation-expectations",
+  "h_state": "H2",
+  "epistemic_counts": {
+    "fact": 2,
+    "forecast": 1,
+    "correlation": 1,
+    "causality": 1,
+    "counterevidence": 1
+  },
+  "supporting_evidence_ids": [
+    "evd-synthetic-001"
+  ],
+  "refuting_evidence_ids": [],
+  "hypothesis_assessment_ids": [
+    "hya-synthetic-r3-001"
+  ],
+  "direction": "strengthening",
+  "material_delta": true,
+  "common_cause_refs": [
+    "synthetic-common-cause"
+  ],
+  "notes": "Synthetic fixture only.",
+  "as_of": "2026-08-31T06:10:00Z",
+  "sensitivity": "public"
+}

--- a/examples/synthetic/chain-watch-snapshot.json
+++ b/examples/synthetic/chain-watch-snapshot.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "0.1.0",
+  "snapshot_id": "chs-synthetic-r6-001",
+  "chain_id": "chn-climate-food-energy-inflation-ai-v0.1",
+  "previous_snapshot_id": null,
+  "as_of": "2026-08-31T06:15:00Z",
+  "ordered_link_assessment_ids": [
+    "cla-chain-1",
+    "cla-chain-2",
+    "cla-chain-3",
+    "cla-chain-4",
+    "cla-chain-5"
+  ],
+  "total_link_count": 5,
+  "supported_link_count": 5,
+  "h3_link_count": 0,
+  "forecast_only_link_count": 0,
+  "falsified_link_count": 0,
+  "strengthening_link_count": 5,
+  "weakening_link_count": 0,
+  "material_link_count": 5,
+  "longest_contiguous_supported_path": 5,
+  "full_chain_supported": true,
+  "chain_state": "TRANSMITTING",
+  "sensitivity": "public"
+}

--- a/examples/synthetic/chain-watch-snapshot.json
+++ b/examples/synthetic/chain-watch-snapshot.json
@@ -22,5 +22,7 @@
   "longest_contiguous_supported_path": 5,
   "full_chain_supported": true,
   "chain_state": "TRANSMITTING",
-  "sensitivity": "public"
+  "sensitivity": "public",
+  "required_link_count": 5,
+  "falsified_required_link_count": 0
 }

--- a/schemas/chain-definition.schema.json
+++ b/schemas/chain-definition.schema.json
@@ -1,0 +1,164 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/chain-definition.schema.json",
+  "title": "Chain Watch Definition",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "chain_id",
+    "title",
+    "purpose",
+    "nodes",
+    "links",
+    "created_at",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "chain_id": {
+      "type": "string",
+      "pattern": "^chn-[A-Za-z0-9._-]+$"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "purpose": {
+      "type": "string",
+      "minLength": 1
+    },
+    "nodes": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "node_id",
+          "label",
+          "description",
+          "observation_domains",
+          "risk_variables"
+        ],
+        "properties": {
+          "node_id": {
+            "type": "string",
+            "pattern": "^chnode-[A-Za-z0-9._-]+$"
+          },
+          "label": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "observation_domains": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "risk_variables": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "enum": [
+                "A",
+                "B",
+                "C",
+                "D"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "links": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "link_id",
+          "source_node_id",
+          "target_node_id",
+          "mechanism",
+          "required",
+          "expected_latency_days",
+          "persistence_note"
+        ],
+        "properties": {
+          "link_id": {
+            "type": "string",
+            "pattern": "^chlink-[A-Za-z0-9._-]+$"
+          },
+          "source_node_id": {
+            "type": "string",
+            "pattern": "^chnode-[A-Za-z0-9._-]+$"
+          },
+          "target_node_id": {
+            "type": "string",
+            "pattern": "^chnode-[A-Za-z0-9._-]+$"
+          },
+          "mechanism": {
+            "type": "string",
+            "minLength": 1
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "expected_latency_days": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "min",
+                  "max"
+                ],
+                "properties": {
+                  "min": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "max": {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                }
+              }
+            ]
+          },
+          "persistence_note": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/chain-link-assessment.schema.json
+++ b/schemas/chain-link-assessment.schema.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/chain-link-assessment.schema.json",
+  "title": "Chain Link Assessment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "assessment_id",
+    "chain_id",
+    "link_id",
+    "source_node_id",
+    "target_node_id",
+    "h_state",
+    "epistemic_counts",
+    "supporting_evidence_ids",
+    "refuting_evidence_ids",
+    "hypothesis_assessment_ids",
+    "direction",
+    "material_delta",
+    "common_cause_refs",
+    "as_of",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "assessment_id": {
+      "type": "string",
+      "pattern": "^cla-[A-Za-z0-9._-]+$"
+    },
+    "chain_id": {
+      "type": "string",
+      "pattern": "^chn-[A-Za-z0-9._-]+$"
+    },
+    "link_id": {
+      "type": "string",
+      "pattern": "^chlink-[A-Za-z0-9._-]+$"
+    },
+    "source_node_id": {
+      "type": "string",
+      "pattern": "^chnode-[A-Za-z0-9._-]+$"
+    },
+    "target_node_id": {
+      "type": "string",
+      "pattern": "^chnode-[A-Za-z0-9._-]+$"
+    },
+    "h_state": {
+      "enum": [
+        "H0",
+        "H1",
+        "H2",
+        "H3",
+        "Hx"
+      ]
+    },
+    "epistemic_counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "fact",
+        "forecast",
+        "correlation",
+        "causality",
+        "counterevidence"
+      ],
+      "properties": {
+        "fact": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "forecast": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "correlation": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "causality": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "counterevidence": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "supporting_evidence_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^evd-[A-Za-z0-9._-]+$"
+      }
+    },
+    "refuting_evidence_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^evd-[A-Za-z0-9._-]+$"
+      }
+    },
+    "hypothesis_assessment_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^hya-[A-Za-z0-9._-]+$"
+      }
+    },
+    "direction": {
+      "enum": [
+        "strengthening",
+        "weakening",
+        "stable",
+        "uncertain",
+        "falsified"
+      ]
+    },
+    "material_delta": {
+      "type": "boolean"
+    },
+    "common_cause_refs": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "notes": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "as_of": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/chain-watch-snapshot.schema.json
+++ b/schemas/chain-watch-snapshot.schema.json
@@ -12,10 +12,12 @@
     "as_of",
     "ordered_link_assessment_ids",
     "total_link_count",
+    "required_link_count",
     "supported_link_count",
     "h3_link_count",
     "forecast_only_link_count",
     "falsified_link_count",
+    "falsified_required_link_count",
     "strengthening_link_count",
     "weakening_link_count",
     "material_link_count",
@@ -117,6 +119,14 @@
         "confidential",
         "restricted"
       ]
+    },
+    "required_link_count": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "falsified_required_link_count": {
+      "type": "integer",
+      "minimum": 0
     }
   }
 }

--- a/schemas/chain-watch-snapshot.schema.json
+++ b/schemas/chain-watch-snapshot.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/chain-watch-snapshot.schema.json",
+  "title": "Chain Watch Snapshot",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "snapshot_id",
+    "chain_id",
+    "previous_snapshot_id",
+    "as_of",
+    "ordered_link_assessment_ids",
+    "total_link_count",
+    "supported_link_count",
+    "h3_link_count",
+    "forecast_only_link_count",
+    "falsified_link_count",
+    "strengthening_link_count",
+    "weakening_link_count",
+    "material_link_count",
+    "longest_contiguous_supported_path",
+    "full_chain_supported",
+    "chain_state",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "snapshot_id": {
+      "type": "string",
+      "pattern": "^chs-[A-Za-z0-9._-]+$"
+    },
+    "chain_id": {
+      "type": "string",
+      "pattern": "^chn-[A-Za-z0-9._-]+$"
+    },
+    "previous_snapshot_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^chs-[A-Za-z0-9._-]+$"
+    },
+    "as_of": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "ordered_link_assessment_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^cla-[A-Za-z0-9._-]+$"
+      }
+    },
+    "total_link_count": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "supported_link_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "h3_link_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "forecast_only_link_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "falsified_link_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "strengthening_link_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "weakening_link_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "material_link_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "longest_contiguous_supported_path": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "full_chain_supported": {
+      "type": "boolean"
+    },
+    "chain_state": {
+      "enum": [
+        "UNKNOWN",
+        "FRAGMENTED",
+        "BUILDING",
+        "TRANSMITTING",
+        "RELAXING",
+        "BROKEN"
+      ]
+    },
+    "notes": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/scripts/validate_schemas.py
+++ b/scripts/validate_schemas.py
@@ -224,8 +224,8 @@ def semantic_errors(name, obj):
             errors.append("chain node_id values must be unique")
         if len(link_ids) != len(set(link_ids)):
             errors.append("chain link_id values must be unique")
-        if not any(link["required"] for link in obj["links"]):
-            errors.append("chain requires at least one required link")
+        if not all(link["required"] for link in obj["links"]):
+            errors.append("v0.1 canonical linear chain requires every link to be required")
         node_set = set(node_ids)
         for link in obj["links"]:
             if link["source_node_id"] == link["target_node_id"]:

--- a/scripts/validate_schemas.py
+++ b/scripts/validate_schemas.py
@@ -45,6 +45,9 @@ PAIRS = {
     "posterior_revision": ("schemas/posterior-revision.schema.json", "examples/synthetic/posterior-revision.json"),
     "alert_history_record": ("schemas/alert-history-record.schema.json", "examples/synthetic/alert-history-record.json"),
     "judgment_calibration_summary": ("schemas/judgment-calibration-summary.schema.json", "examples/synthetic/judgment-calibration-summary.json"),
+    "chain_definition": ("schemas/chain-definition.schema.json", "chains/climate-food-energy-inflation-ai.json"),
+    "chain_link_assessment": ("schemas/chain-link-assessment.schema.json", "examples/synthetic/chain-link-assessment.json"),
+    "chain_watch_snapshot": ("schemas/chain-watch-snapshot.schema.json", "examples/synthetic/chain-watch-snapshot.json"),
 }
 
 def load(path):
@@ -214,6 +217,75 @@ def semantic_errors(name, obj):
             errors.append("calibration must contain one latest judgment_id per total_count")
         if len(obj["outcome_ids"]) != total:
             errors.append("calibration must contain one selected outcome_id per total_count")
+    elif name == "chain_definition":
+        node_ids = [node["node_id"] for node in obj["nodes"]]
+        link_ids = [link["link_id"] for link in obj["links"]]
+        if len(node_ids) != len(set(node_ids)):
+            errors.append("chain node_id values must be unique")
+        if len(link_ids) != len(set(link_ids)):
+            errors.append("chain link_id values must be unique")
+        if not any(link["required"] for link in obj["links"]):
+            errors.append("chain requires at least one required link")
+        node_set = set(node_ids)
+        for link in obj["links"]:
+            if link["source_node_id"] == link["target_node_id"]:
+                errors.append("chain link cannot self-loop")
+            if link["source_node_id"] not in node_set or link["target_node_id"] not in node_set:
+                errors.append("chain link endpoints must reference defined nodes")
+            latency = link["expected_latency_days"]
+            if latency is not None and latency["min"] > latency["max"]:
+                errors.append("chain expected latency min must be <= max")
+        for left, right in zip(obj["links"], obj["links"][1:]):
+            if left["target_node_id"] != right["source_node_id"]:
+                errors.append("v0.1 canonical chain links must form an ordered contiguous path")
+    elif name == "chain_link_assessment":
+        counts = obj["epistemic_counts"]
+        forecast_only = (
+            counts["forecast"] > 0
+            and counts["fact"] == 0
+            and counts["correlation"] == 0
+            and counts["causality"] == 0
+        )
+        if forecast_only and obj["h_state"] in {"H2", "H3"}:
+            errors.append("forecast-only link cannot claim H2/H3 chain transmission")
+        if counts["causality"] > 0 and not obj["supporting_evidence_ids"]:
+            errors.append("causal evidence count requires supporting_evidence_ids")
+        if obj["h_state"] == "Hx" and obj["direction"] != "falsified":
+            errors.append("Hx link must use direction=falsified")
+        if obj["direction"] == "falsified" and obj["h_state"] != "Hx":
+            errors.append("direction=falsified requires Hx")
+    elif name == "chain_watch_snapshot":
+        total = obj["total_link_count"]
+        required = obj["required_link_count"]
+        if required > total:
+            errors.append("required_link_count cannot exceed total_link_count")
+        for field in (
+            "supported_link_count",
+            "h3_link_count",
+            "forecast_only_link_count",
+            "falsified_link_count",
+            "falsified_required_link_count",
+            "strengthening_link_count",
+            "weakening_link_count",
+            "material_link_count",
+        ):
+            if obj[field] > total:
+                errors.append(f"{field} cannot exceed total_link_count")
+        if obj["falsified_required_link_count"] > obj["falsified_link_count"]:
+            errors.append("falsified required links cannot exceed all falsified links")
+        if obj["longest_contiguous_supported_path"] > obj["supported_link_count"]:
+            errors.append("longest contiguous path cannot exceed supported_link_count")
+        if obj["full_chain_supported"] and obj["chain_state"] != "TRANSMITTING":
+            errors.append("full_chain_supported requires TRANSMITTING")
+        if obj["chain_state"] == "TRANSMITTING" and not obj["full_chain_supported"]:
+            errors.append("TRANSMITTING requires full_chain_supported")
+        if obj["chain_state"] == "BROKEN" and obj["falsified_required_link_count"] == 0:
+            errors.append("BROKEN requires a falsified required link")
+        if obj["chain_state"] == "BUILDING" and obj["longest_contiguous_supported_path"] < 2:
+            errors.append("BUILDING requires a contiguous supported path of at least 2")
+        if obj["chain_state"] == "FRAGMENTED":
+            if obj["supported_link_count"] == 0 or obj["longest_contiguous_supported_path"] > 1:
+                errors.append("FRAGMENTED requires isolated supported links")
     elif name == "structural_delta":
         h_order = {"H0": 0, "H1": 1, "H2": 2, "H3": 3}
         c_order = {"C0": 0, "C1": 1, "C2": 2, "C3": 3}

--- a/src/psrro/__init__.py
+++ b/src/psrro/__init__.py
@@ -1,3 +1,9 @@
+from .intelligence_chain import (
+    build_chain_snapshot,
+    is_chain_supported_link,
+    is_forecast_only,
+    longest_contiguous_supported_path,
+)
 from .intelligence_memory import (
     JudgmentMemoryStore,
     claim_grade_changed,
@@ -40,6 +46,10 @@ from .quantification import (
 )
 
 __all__ = [
+    "build_chain_snapshot",
+    "is_chain_supported_link",
+    "is_forecast_only",
+    "longest_contiguous_supported_path",
     "JudgmentMemoryStore",
     "claim_grade_changed",
     "summarize_judgment_calibration",

--- a/src/psrro/intelligence_chain.py
+++ b/src/psrro/intelligence_chain.py
@@ -91,6 +91,7 @@ def build_chain_snapshot(
     supported_count = sum(supported)
     h3_count = sum(a["h_state"] == "H3" and is_chain_supported_link(a) for a in ordered)
     forecast_only_count = sum(is_forecast_only(a) for a in ordered)
+    falsified_count = sum(a["h_state"] == "Hx" for a in ordered)
     falsified_required_count = sum(
         link["required"] and assessment_map[link["link_id"]]["h_state"] == "Hx"
         for link in definition["links"]
@@ -104,6 +105,8 @@ def build_chain_snapshot(
     required_links = [
         link["link_id"] for link in definition["links"] if link["required"]
     ]
+    if not required_links:
+        raise ValueError("chain definition must contain at least one required link")
     full_chain_supported = all(
         is_chain_supported_link(assessment_map[link_id])
         for link_id in required_links
@@ -136,10 +139,12 @@ def build_chain_snapshot(
         "as_of": as_of,
         "ordered_link_assessment_ids": [a["assessment_id"] for a in ordered],
         "total_link_count": len(ordered),
+        "required_link_count": len(required_links),
         "supported_link_count": supported_count,
         "h3_link_count": h3_count,
         "forecast_only_link_count": forecast_only_count,
-        "falsified_link_count": falsified_required_count,
+        "falsified_link_count": falsified_count,
+        "falsified_required_link_count": falsified_required_count,
         "strengthening_link_count": strengthening_count,
         "weakening_link_count": weakening_count,
         "material_link_count": material_count,

--- a/src/psrro/intelligence_chain.py
+++ b/src/psrro/intelligence_chain.py
@@ -1,0 +1,150 @@
+"""Phase 3R-06 Chain Watch.
+
+A chain is only as strong as its actual directed links. Forecast/correlation
+can inform a link but cannot by themselves establish causal transmission.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+
+SUPPORTED_H_STATES = {"H2", "H3"}
+
+
+def is_forecast_only(assessment: Mapping) -> bool:
+    counts = assessment["epistemic_counts"]
+    return (
+        counts["forecast"] > 0
+        and counts["fact"] == 0
+        and counts["correlation"] == 0
+        and counts["causality"] == 0
+    )
+
+
+def is_chain_supported_link(assessment: Mapping) -> bool:
+    """Chain support requires H2/H3 plus explicit causal evidence."""
+    return (
+        assessment["h_state"] in SUPPORTED_H_STATES
+        and assessment["epistemic_counts"]["causality"] > 0
+        and assessment["direction"] != "falsified"
+    )
+
+
+def longest_contiguous_supported_path(
+    definition: Mapping,
+    assessments_by_link: Mapping[str, Mapping],
+) -> int:
+    longest = 0
+    current = 0
+    for link in definition["links"]:
+        assessment = assessments_by_link[link["link_id"]]
+        if is_chain_supported_link(assessment):
+            current += 1
+            longest = max(longest, current)
+        else:
+            current = 0
+    return longest
+
+
+def build_chain_snapshot(
+    definition: Mapping,
+    assessments: Sequence[Mapping],
+    *,
+    snapshot_id: str = "chs-derived",
+    as_of: str = "1970-01-01T00:00:00Z",
+    previous_snapshot: Mapping | None = None,
+    sensitivity: str = "public",
+) -> dict:
+    """Derive a descriptive chain state without creating a chain risk score."""
+
+    if not definition["links"]:
+        raise ValueError("chain definition must contain at least one link")
+
+    link_ids = [link["link_id"] for link in definition["links"]]
+    assessment_map: dict[str, Mapping] = {}
+
+    for assessment in assessments:
+        if assessment["chain_id"] != definition["chain_id"]:
+            raise ValueError("assessment chain_id does not match definition")
+        link_id = assessment["link_id"]
+        if link_id in assessment_map:
+            raise ValueError(f"duplicate assessment for link {link_id}")
+        assessment_map[link_id] = assessment
+
+    if set(assessment_map) != set(link_ids):
+        missing = sorted(set(link_ids) - set(assessment_map))
+        extra = sorted(set(assessment_map) - set(link_ids))
+        raise ValueError(f"assessment coverage mismatch missing={missing} extra={extra}")
+
+    # Validate assessment endpoints against the definition.
+    for link in definition["links"]:
+        assessment = assessment_map[link["link_id"]]
+        if assessment["source_node_id"] != link["source_node_id"]:
+            raise ValueError(f"source node mismatch for {link['link_id']}")
+        if assessment["target_node_id"] != link["target_node_id"]:
+            raise ValueError(f"target node mismatch for {link['link_id']}")
+
+    ordered = [assessment_map[link_id] for link_id in link_ids]
+
+    supported = [is_chain_supported_link(a) for a in ordered]
+    supported_count = sum(supported)
+    h3_count = sum(a["h_state"] == "H3" and is_chain_supported_link(a) for a in ordered)
+    forecast_only_count = sum(is_forecast_only(a) for a in ordered)
+    falsified_required_count = sum(
+        link["required"] and assessment_map[link["link_id"]]["h_state"] == "Hx"
+        for link in definition["links"]
+    )
+    strengthening_count = sum(a["direction"] == "strengthening" for a in ordered)
+    weakening_count = sum(a["direction"] == "weakening" for a in ordered)
+    material_count = sum(bool(a["material_delta"]) for a in ordered)
+
+    longest = longest_contiguous_supported_path(definition, assessment_map)
+
+    required_links = [
+        link["link_id"] for link in definition["links"] if link["required"]
+    ]
+    full_chain_supported = all(
+        is_chain_supported_link(assessment_map[link_id])
+        for link_id in required_links
+    )
+
+    if falsified_required_count:
+        chain_state = "BROKEN"
+    elif full_chain_supported:
+        chain_state = "TRANSMITTING"
+    elif (
+        previous_snapshot is not None
+        and previous_snapshot["chain_state"] in {"BUILDING", "TRANSMITTING"}
+        and weakening_count > strengthening_count
+    ):
+        chain_state = "RELAXING"
+    elif longest >= 2:
+        chain_state = "BUILDING"
+    elif supported_count > 0:
+        chain_state = "FRAGMENTED"
+    else:
+        chain_state = "UNKNOWN"
+
+    return {
+        "schema_version": "0.1.0",
+        "snapshot_id": snapshot_id,
+        "chain_id": definition["chain_id"],
+        "previous_snapshot_id": (
+            None if previous_snapshot is None else previous_snapshot["snapshot_id"]
+        ),
+        "as_of": as_of,
+        "ordered_link_assessment_ids": [a["assessment_id"] for a in ordered],
+        "total_link_count": len(ordered),
+        "supported_link_count": supported_count,
+        "h3_link_count": h3_count,
+        "forecast_only_link_count": forecast_only_count,
+        "falsified_link_count": falsified_required_count,
+        "strengthening_link_count": strengthening_count,
+        "weakening_link_count": weakening_count,
+        "material_link_count": material_count,
+        "longest_contiguous_supported_path": longest,
+        "full_chain_supported": full_chain_supported,
+        "chain_state": chain_state,
+        "sensitivity": sensitivity,
+    }

--- a/src/psrro/intelligence_chain.py
+++ b/src/psrro/intelligence_chain.py
@@ -27,6 +27,7 @@ def is_chain_supported_link(assessment: Mapping) -> bool:
     return (
         assessment["h_state"] in SUPPORTED_H_STATES
         and assessment["epistemic_counts"]["causality"] > 0
+        and bool(assessment.get("supporting_evidence_ids"))
         and assessment["direction"] != "falsified"
     )
 
@@ -60,6 +61,8 @@ def build_chain_snapshot(
 
     if not definition["links"]:
         raise ValueError("chain definition must contain at least one link")
+    if any(not link["required"] for link in definition["links"]):
+        raise ValueError("v0.1 linear Chain Watch requires every canonical link to be required")
 
     link_ids = [link["link_id"] for link in definition["links"]]
     assessment_map: dict[str, Mapping] = {}

--- a/tests/test_intelligence_chain.py
+++ b/tests/test_intelligence_chain.py
@@ -29,6 +29,7 @@ def assessment(link, idx, h="H1", causality=0, forecast=0, direction="stable", m
         "source_node_id": link["source_node_id"],
         "target_node_id": link["target_node_id"],
         "h_state": h,
+        "supporting_evidence_ids": ["evd-chain-synthetic"] if causality > 0 else [],
         "epistemic_counts": {
             "fact": 0,
             "forecast": forecast,
@@ -79,6 +80,11 @@ class LinkSupportTests(unittest.TestCase):
     def test_h2_with_causal_evidence_is_supported(self):
         row = assessment(definition()["links"][0], 1, h="H2", causality=1)
         self.assertTrue(is_chain_supported_link(row))
+
+    def test_causal_count_without_evidence_ref_fails_closed(self):
+        row = assessment(definition()["links"][0], 1, h="H2", causality=1)
+        row["supporting_evidence_ids"] = []
+        self.assertFalse(is_chain_supported_link(row))
 
 
 class SnapshotTests(unittest.TestCase):

--- a/tests/test_intelligence_chain.py
+++ b/tests/test_intelligence_chain.py
@@ -1,0 +1,153 @@
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from src.psrro.intelligence_chain import (
+    build_chain_snapshot,
+    is_chain_supported_link,
+    is_forecast_only,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def definition():
+    return json.loads(
+        (ROOT / "chains" / "climate-food-energy-inflation-ai.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+
+def assessment(link, idx, h="H1", causality=0, forecast=0, direction="stable", material=False):
+    return {
+        "assessment_id": f"cla-test-{idx}",
+        "chain_id": "chn-climate-food-energy-inflation-ai-v0.1",
+        "link_id": link["link_id"],
+        "source_node_id": link["source_node_id"],
+        "target_node_id": link["target_node_id"],
+        "h_state": h,
+        "epistemic_counts": {
+            "fact": 0,
+            "forecast": forecast,
+            "correlation": 0,
+            "causality": causality,
+            "counterevidence": 0,
+        },
+        "direction": direction,
+        "material_delta": material,
+    }
+
+
+def all_assessments(h="H1", causality=0, direction="stable"):
+    d = definition()
+    return [
+        assessment(link, idx, h=h, causality=causality, direction=direction)
+        for idx, link in enumerate(d["links"], start=1)
+    ]
+
+
+class LinkSupportTests(unittest.TestCase):
+    def test_forecast_only_is_not_chain_support(self):
+        row = assessment(definition()["links"][0], 1, h="H2", forecast=2)
+        self.assertTrue(is_forecast_only(row))
+        self.assertFalse(is_chain_supported_link(row))
+
+    def test_h2_with_causal_evidence_is_supported(self):
+        row = assessment(definition()["links"][0], 1, h="H2", causality=1)
+        self.assertTrue(is_chain_supported_link(row))
+
+
+class SnapshotTests(unittest.TestCase):
+    def test_full_h2_causal_chain_is_transmitting(self):
+        d = definition()
+        rows = all_assessments(h="H2", causality=1, direction="strengthening")
+        result = build_chain_snapshot(d, rows)
+        self.assertEqual(result["chain_state"], "TRANSMITTING")
+        self.assertTrue(result["full_chain_supported"])
+        self.assertEqual(
+            result["longest_contiguous_supported_path"],
+            len(d["links"]),
+        )
+
+    def test_required_hx_breaks_chain(self):
+        d = definition()
+        rows = all_assessments(h="H2", causality=1)
+        rows[2]["h_state"] = "Hx"
+        rows[2]["direction"] = "falsified"
+        result = build_chain_snapshot(d, rows)
+        self.assertEqual(result["chain_state"], "BROKEN")
+        self.assertFalse(result["full_chain_supported"])
+
+    def test_isolated_supported_links_are_fragmented(self):
+        d = definition()
+        rows = all_assessments()
+        rows[0]["h_state"] = "H2"
+        rows[0]["epistemic_counts"]["causality"] = 1
+        rows[2]["h_state"] = "H2"
+        rows[2]["epistemic_counts"]["causality"] = 1
+        result = build_chain_snapshot(d, rows)
+        self.assertEqual(result["chain_state"], "FRAGMENTED")
+        self.assertEqual(result["longest_contiguous_supported_path"], 1)
+
+    def test_two_contiguous_supported_links_are_building(self):
+        d = definition()
+        rows = all_assessments()
+        for idx in (1, 2):
+            rows[idx]["h_state"] = "H2"
+            rows[idx]["epistemic_counts"]["causality"] = 1
+            rows[idx]["direction"] = "strengthening"
+        result = build_chain_snapshot(d, rows)
+        self.assertEqual(result["chain_state"], "BUILDING")
+        self.assertEqual(result["longest_contiguous_supported_path"], 2)
+
+    def test_previous_active_chain_can_relax(self):
+        d = definition()
+        previous_rows = all_assessments(h="H2", causality=1)
+        previous = build_chain_snapshot(
+            d,
+            previous_rows,
+            snapshot_id="chs-previous",
+        )
+        current_rows = all_assessments()
+        current_rows[0]["h_state"] = "H2"
+        current_rows[0]["epistemic_counts"]["causality"] = 1
+        current_rows[0]["direction"] = "weakening"
+        current_rows[1]["direction"] = "weakening"
+        result = build_chain_snapshot(
+            d,
+            current_rows,
+            previous_snapshot=previous,
+        )
+        self.assertEqual(result["chain_state"], "RELAXING")
+        self.assertEqual(result["previous_snapshot_id"], "chs-previous")
+
+    def test_order_of_input_assessments_does_not_change_output_order(self):
+        d = definition()
+        rows = all_assessments(h="H2", causality=1)
+        forward = build_chain_snapshot(d, rows)
+        reverse = build_chain_snapshot(d, list(reversed(rows)))
+        self.assertEqual(
+            forward["ordered_link_assessment_ids"],
+            reverse["ordered_link_assessment_ids"],
+        )
+
+    def test_missing_link_assessment_fails_closed(self):
+        d = definition()
+        rows = all_assessments()
+        with self.assertRaises(ValueError):
+            build_chain_snapshot(d, rows[:-1])
+
+    def test_duplicate_link_assessment_fails_closed(self):
+        d = definition()
+        rows = all_assessments()
+        rows.append(copy.deepcopy(rows[0]))
+        rows[-1]["assessment_id"] = "cla-duplicate"
+        with self.assertRaises(ValueError):
+            build_chain_snapshot(d, rows)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_intelligence_chain.py
+++ b/tests/test_intelligence_chain.py
@@ -23,7 +23,7 @@ def definition():
 
 def assessment(link, idx, h="H1", causality=0, forecast=0, direction="stable", material=False):
     return {
-        "assessment_id": f"cla-test-{idx}",
+        "assessment_id": f"cla-chain-{idx}",
         "chain_id": "chn-climate-food-energy-inflation-ai-v0.1",
         "link_id": link["link_id"],
         "source_node_id": link["source_node_id"],
@@ -47,6 +47,27 @@ def all_assessments(h="H1", causality=0, direction="stable"):
         assessment(link, idx, h=h, causality=causality, direction=direction)
         for idx, link in enumerate(d["links"], start=1)
     ]
+
+
+class ExampleContractTests(unittest.TestCase):
+    def test_full_transmitting_snapshot_matches_fixture(self):
+        d = definition()
+        rows = all_assessments(h="H2", causality=1, direction="strengthening")
+        for row in rows:
+            row["material_delta"] = True
+        expected = json.loads(
+            (ROOT / "examples" / "synthetic" / "chain-watch-snapshot.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        actual = build_chain_snapshot(
+            d,
+            rows,
+            snapshot_id=expected["snapshot_id"],
+            as_of=expected["as_of"],
+            sensitivity=expected["sensitivity"],
+        )
+        self.assertEqual(actual, expected)
 
 
 class LinkSupportTests(unittest.TestCase):

--- a/tests/test_intelligence_chain.py
+++ b/tests/test_intelligence_chain.py
@@ -113,8 +113,10 @@ class SnapshotTests(unittest.TestCase):
         rows = all_assessments()
         rows[0]["h_state"] = "H2"
         rows[0]["epistemic_counts"]["causality"] = 1
+        rows[0]["supporting_evidence_ids"] = ["evd-chain-synthetic"]
         rows[2]["h_state"] = "H2"
         rows[2]["epistemic_counts"]["causality"] = 1
+        rows[2]["supporting_evidence_ids"] = ["evd-chain-synthetic"]
         result = build_chain_snapshot(d, rows)
         self.assertEqual(result["chain_state"], "FRAGMENTED")
         self.assertEqual(result["longest_contiguous_supported_path"], 1)
@@ -125,6 +127,7 @@ class SnapshotTests(unittest.TestCase):
         for idx in (1, 2):
             rows[idx]["h_state"] = "H2"
             rows[idx]["epistemic_counts"]["causality"] = 1
+            rows[idx]["supporting_evidence_ids"] = ["evd-chain-synthetic"]
             rows[idx]["direction"] = "strengthening"
         result = build_chain_snapshot(d, rows)
         self.assertEqual(result["chain_state"], "BUILDING")
@@ -141,6 +144,7 @@ class SnapshotTests(unittest.TestCase):
         current_rows = all_assessments()
         current_rows[0]["h_state"] = "H2"
         current_rows[0]["epistemic_counts"]["causality"] = 1
+        current_rows[0]["supporting_evidence_ids"] = ["evd-chain-synthetic"]
         current_rows[0]["direction"] = "weakening"
         current_rows[1]["direction"] = "weakening"
         result = build_chain_snapshot(


### PR DESCRIPTION
Closes #34

## Implements

- canonical Chain Definition schema
- Chain Link Assessment schema
- Chain Watch Snapshot schema
- first public chain:
  Climate/El Niño
  → Food & Energy Pressure
  → Inflation / Inflation Expectations
  → Fed / Monetary Policy
  → UST Long End / Financial Conditions / Fiscal Pressure
  → AI CapEx / Tech Valuation / Financing Stress
- deterministic link-support logic
- longest contiguous supported-path detection
- UNKNOWN / FRAGMENTED / BUILDING / TRANSMITTING / RELAXING / BROKEN chain states
- previous-snapshot relaxation logic
- exact synthetic snapshot contract
- R5 complete / R6 current project-state update

## Core invariants

- forecast-only evidence cannot establish chain transmission
- correlation-only evidence cannot establish chain transmission
- H2/H3 support additionally requires explicit causality evidence and a supporting Evidence ref
- Hx on any required link breaks the canonical chain
- isolated supported links remain FRAGMENTED
- at least two contiguous supported links may be BUILDING
- full required path support is required for TRANSMITTING
- previous active chain can RELAX
- common-cause refs remain explicit
- no chain score / no automatic Global Stage update

## v0.1 constraint

The canonical Chain Watch is a single ordered linear path and every canonical link is required. Branching/alternative mechanisms are deferred rather than approximated badly.

## Non-goals

No automatic causal inference from headlines, notification transport, crawler/scheduler or private operational data.
