### PR TITLE
Project Engine v0.1: dual-repo operating workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,192 @@
+# AGENTS.md — Personal Systemic Risk & Resilience OS
+
+This file is the mandatory entry point for any ChatGPT, Codex, or other engineering agent working on this project.
+
+## 0. Do not trust chat memory as engineering truth
+
+The project uses two repositories:
+
+- PUBLIC method repository: `yeqilei0328-creator/personal-systemic-risk-resilience-os`
+- PRIVATE operational-state repository: `yeqilei0328-creator/personal-systemic-risk-resilience-state`
+
+GitHub `main` is authoritative for both repositories.
+
+A conversation, handoff prompt, Issue body, previous SHA, local checkout, or model memory may be stale. Always fresh-read before changing anything.
+
+## 1. Mandatory startup sequence
+
+Before implementation:
+
+1. Fresh-read PUBLIC `main`:
+   - `AGENTS.md`
+   - `docs/PROJECT-ENGINE.md`
+   - `docs/PROJECT-STATE.md`
+   - `docs/ROADMAP.md`
+   - current-domain method/schema/docs
+   - open Issues / PRs
+   - current CI
+
+2. Fresh-read PRIVATE `main` if authorized:
+   - `AGENTS.md`
+   - `docs/STATE-OPERATING-MODEL.md`
+   - `state-manifest.json`
+   - `vendor/method-pin.json`
+   - `preparedness/current.json`
+   - current-domain audit/assessment/plan
+   - open Issues / PRs
+   - current CI
+
+3. State the recovered checkpoint internally before writing:
+   - PUBLIC main SHA
+   - PRIVATE main SHA
+   - current phase/domain
+   - open work
+   - current blockers
+   - next exact engineering action
+
+Do not ask the user to repeat repository state that can be recovered from GitHub.
+
+## 2. Authority boundary
+
+PUBLIC `main` is authoritative for:
+- architecture
+- schemas
+- algorithms
+- verification methods
+- risk logic
+- public-safe synthetic examples
+- public workflow / Project Engine
+
+PRIVATE `main` is authoritative for:
+- real capability state
+- real evidence
+- real dependencies / SPOFs
+- real measurements
+- real operational topology
+- preparedness snapshot
+- real autonomy / first-failure state when defensible
+
+Never write real private values into the PUBLIC repository.
+
+Never place secrets in either repository.
+
+## 3. Method pin invariant
+
+PRIVATE state must be interpreted by a pinned PUBLIC method.
+
+Before advancing `vendor/method-pin.json`:
+1. compare every existing vendored file SHA with the candidate PUBLIC `main`;
+2. require all unchanged files to match, or perform an explicit migration;
+3. vendor the new method/schema files;
+4. update the pin;
+5. recompute stored assessments with the pinned code;
+6. require PRIVATE CI PASS.
+
+Do not silently mix methods from different public commits.
+
+## 4. Domain execution loop
+
+For each capability domain:
+
+### A. Public method
+If a verification method is missing:
+Issue → branch → schema → deterministic logic → synthetic examples → tests → docs → unified validator → PR → CI → review → merge.
+
+### B. Private baseline
+After public method merge:
+pin audit → vendor method → restricted audit → deterministic assessment → field/measurement plan → capability link → manifest → private validator → PR → CI → review → merge.
+
+### C. Evidence discipline
+`stated ≠ measured ≠ field_tested ≠ audited`
+
+Ownership is not autonomy.
+
+Unknown remains unknown.
+
+Stored assessments must equal deterministic derivation from the pinned method.
+
+## 5. Model First → Batch Field Validation
+
+Do not interrupt every domain with immediate field work.
+
+Default workflow:
+1. build the method;
+2. instantiate a conservative PRIVATE baseline;
+3. infer dependencies, SPOFs, blockers and required evidence;
+4. write the field-test plan;
+5. continue through the current modelling wave;
+6. only after the wave is fully modelled, generate one consolidated field work order;
+7. collect field evidence in a coordinated site session;
+8. update PRIVATE evidence/state;
+9. recompute assessments and Preparedness.
+
+Current first field wave:
+**Water + Energy + Communications / Network / Offline Compute.**
+
+Field work is not complete until cross-domain dependencies are tested together, especially:
+- Water pump ↔ Energy
+- Communications/local compute ↔ Energy
+- Physical AI ↔ Communications/local compute
+- Offline knowledge ↔ local compute
+
+## 6. Fail-closed rules
+
+Do not invent:
+- autonomy days
+- availability
+- independent communication paths
+- potability
+- islanding / black-start
+- agricultural suitability
+- scenario probability
+- Personal R-Level
+
+when required evidence is missing.
+
+`拥有 ≠ 可用；可用 ≠ 可持续；可持续 ≠ 自给。`
+
+## 7. PR / CI discipline
+
+- Work on a branch.
+- Use PR review as the merge gate.
+- Validate the final head, not an earlier green commit.
+- Merge with the expected head SHA.
+- If CI catches a bad fixture but the algorithm is correct, fix the fixture.
+- Never weaken a safety/evidence rule solely to make CI green.
+- Update Project State/Roadmap only when the implementation state is true.
+
+## 8. Security boundary
+
+PUBLIC repository must not contain:
+- balances / liabilities / cash flow
+- identifiable site inventories or exact capacities
+- real network/security topology
+- credentials / tokens / private keys
+- people/contact lists
+- exact routes
+- sensitive Physical AI deployment details
+
+PRIVATE repository may contain operational state but still must not contain secrets.
+
+Physical AI work in this project is defensive/non-weaponized.
+
+## 9. Handoff contract
+
+Before ending a significant engineering session, ensure durable state records:
+- exact PUBLIC main SHA
+- exact PRIVATE main SHA
+- current phase/domain
+- merged work
+- open Issue/PR
+- CI state
+- private evidence still missing
+- next exact action
+- whether field work is deferred
+
+The next agent should be able to continue from GitHub without reconstructing the project from conversation history.
+
+## 10. Canonical workflow
+
+Read `docs/PROJECT-ENGINE.md` for the complete operating engine.
+
+If any other project note conflicts with it, current GitHub `main` plus the explicit authority rules in PROJECT-ENGINE take precedence.

--- a/config/project-engine.json
+++ b/config/project-engine.json
@@ -1,0 +1,112 @@
+{
+  "engine_version": "0.1.0",
+  "engine_name": "Personal Systemic Risk & Resilience OS Project Engine",
+  "repositories": {
+    "public_method": {
+      "full_name": "yeqilei0328-creator/personal-systemic-risk-resilience-os",
+      "visibility": "public",
+      "authority": [
+        "architecture",
+        "schemas",
+        "algorithms",
+        "verification_methods",
+        "risk_logic",
+        "project_engine",
+        "public_safe_examples"
+      ]
+    },
+    "private_state": {
+      "full_name": "yeqilei0328-creator/personal-systemic-risk-resilience-state",
+      "visibility": "private",
+      "authority": [
+        "real_capability_state",
+        "real_evidence",
+        "measurements",
+        "dependencies",
+        "spofs",
+        "preparedness",
+        "autonomy_when_defensible"
+      ]
+    }
+  },
+  "startup": {
+    "fresh_read_required": true,
+    "chat_memory_authoritative": false,
+    "required_public_files": [
+      "AGENTS.md",
+      "docs/PROJECT-ENGINE.md",
+      "docs/PROJECT-STATE.md",
+      "docs/ROADMAP.md"
+    ],
+    "required_private_files": [
+      "AGENTS.md",
+      "docs/STATE-OPERATING-MODEL.md",
+      "state-manifest.json",
+      "vendor/method-pin.json",
+      "preparedness/current.json"
+    ]
+  },
+  "invariants": {
+    "open_methodology_private_exposure": true,
+    "private_method_must_be_pinned": true,
+    "stored_private_assessments_must_recompute": true,
+    "unknown_fail_closed": true,
+    "final_head_ci_required": true,
+    "no_secrets_in_git": true,
+    "physical_ai_defensive_only": true
+  },
+  "execution_loop": [
+    "public_method",
+    "private_baseline",
+    "dependency_and_spof_inference",
+    "measurement_plan",
+    "continue_current_modeling_wave",
+    "consolidated_field_validation",
+    "private_evidence_update",
+    "deterministic_recompute",
+    "preparedness_recompute"
+  ],
+  "field_validation": {
+    "doctrine": "model_first_batch_field_later",
+    "current_wave_id": "U1",
+    "current_wave_domains": [
+      "water",
+      "energy",
+      "communications"
+    ],
+    "consolidated_work_order": "FIELD-AUDIT-WAVE-U1.md",
+    "cross_domain_checks": [
+      "water_energy",
+      "communications_energy",
+      "offline_compute_energy",
+      "physical_ai_communications",
+      "offline_knowledge_local_compute"
+    ]
+  },
+  "next_physical_sequence": [
+    "food",
+    "mobility",
+    "sanitation",
+    "medical",
+    "tools_spares",
+    "offline_knowledge",
+    "industrial_space",
+    "land",
+    "physical_ai",
+    "people_network"
+  ],
+  "required_handoff": [
+    "public_main_sha",
+    "private_main_sha",
+    "engine_version",
+    "phase",
+    "domain",
+    "last_merged_pr",
+    "open_prs",
+    "open_issues",
+    "ci_state",
+    "private_method_pin",
+    "deferred_field_evidence",
+    "next_exact_action"
+  ]
+}

--- a/docs/PROJECT-ENGINE.md
+++ b/docs/PROJECT-ENGINE.md
@@ -1,0 +1,598 @@
+# Project Engine v0.1 — Dual-Repository Operating Workflow
+
+## 1. Mission
+
+The Personal Systemic Risk & Resilience OS exists to preserve agency.
+
+It has two coupled jobs:
+
+1. detect material systemic-risk change early enough to create lead time;
+2. convert that lead time into real personal / enterprise / base resilience.
+
+The system is not a doomsday predictor.
+
+A successful system reduces panic because preparation happens before the decision window closes.
+
+> 不是让我比别人更早恐慌，而是让我早到根本不需要恐慌。
+
+---
+
+## 2. The project is one system with two repositories
+
+### PUBLIC METHOD REPOSITORY
+
+`yeqilei0328-creator/personal-systemic-risk-resilience-os`
+
+Role:
+- Project Engine
+- architecture
+- risk model
+- schemas
+- algorithms
+- deterministic verification methods
+- public-safe examples
+- synthetic replay
+- public documentation
+- public CI
+
+Visibility: PUBLIC.
+
+### PRIVATE OPERATIONAL-STATE REPOSITORY
+
+`yeqilei0328-creator/personal-systemic-risk-resilience-state`
+
+Role:
+- real capability records
+- real evidence
+- real measurements
+- real topology/dependencies/SPOFs
+- field-test results
+- current preparedness state
+- current autonomy / First Failure Point when permitted
+
+Visibility: PRIVATE.
+
+### One system, two authorities
+
+The repositories do not compete.
+
+PUBLIC answers:
+
+> “How should this capability be evaluated?”
+
+PRIVATE answers:
+
+> “What is actually true right now?”
+
+The core boundary is:
+
+> **Open methodology, private exposure.**
+
+---
+
+## 3. Engineering truth hierarchy
+
+When sources disagree, use this order.
+
+### For methodology
+1. current PUBLIC `main`
+2. current PUBLIC CI / merged code
+3. current PUBLIC Project State / Roadmap
+4. open PR/Issue execution context
+5. conversation history
+
+### For real operational state
+1. current PRIVATE `main`
+2. current PRIVATE deterministic validator / CI
+3. current PRIVATE evidence records
+4. current PRIVATE Project State / manifest
+5. conversation history
+
+A previous SHA in a prompt is navigation only.
+
+A chat statement is not engineering state until it is persisted appropriately.
+
+---
+
+## 4. Mandatory Fresh-Read Protocol
+
+Every new ChatGPT/Codex session must perform a Fresh Read before implementation.
+
+### PUBLIC Fresh Read
+
+Read:
+1. authoritative `main` SHA;
+2. `AGENTS.md`;
+3. this file;
+4. `docs/PROJECT-STATE.md`;
+5. `docs/ROADMAP.md`;
+6. current domain docs/schema/logic;
+7. open Issues;
+8. open PRs;
+9. latest relevant CI.
+
+### PRIVATE Fresh Read
+
+If authorized, read:
+1. authoritative `main` SHA;
+2. `AGENTS.md`;
+3. `docs/STATE-OPERATING-MODEL.md`;
+4. `state-manifest.json`;
+5. `vendor/method-pin.json`;
+6. `preparedness/current.json`;
+7. current domain audit/assessment/measurement plan;
+8. open Issues;
+9. open PRs;
+10. latest relevant CI.
+
+### Recovery output
+
+Before writing code/state, recover:
+- PUBLIC SHA
+- PRIVATE SHA
+- current phase
+- current domain
+- active branch/PR if any
+- blockers
+- field evidence deferred
+- next exact action
+
+Do not start by trusting the last conversation summary.
+
+---
+
+## 5. The cross-repository transaction
+
+A capability implementation is a two-stage transaction.
+
+### Stage A — PUBLIC method transaction
+
+Trigger:
+- capability lacks an adequate verification method;
+- existing method needs an explicit revision.
+
+Sequence:
+
+`Issue → branch → schema → logic → synthetic example → tests → docs → validator → PR → final-head CI → review → merge`
+
+Exit:
+- method exists on PUBLIC `main`;
+- deterministic tests pass;
+- method can be vendored.
+
+### Stage B — PRIVATE state transaction
+
+Trigger:
+- PUBLIC method exists;
+- real capability needs a baseline or evidence update.
+
+Sequence:
+
+`pin audit → vendor method/schema → private audit → deterministic assessment → measurement plan → capability link → state manifest → validator → PR → final-head CI → review → merge`
+
+Exit:
+- PRIVATE `main` stores current state;
+- stored assessment exactly equals pinned-method derivation;
+- raw private values are not emitted in CI logs.
+
+This pairing is the normal Project Engine cycle.
+
+---
+
+## 6. Method-pin protocol
+
+The PRIVATE repository must never mean “latest public code”.
+
+It means:
+
+> **this exact public method version was used to interpret this exact private state.**
+
+### Pin advancement procedure
+
+Before moving the pin:
+
+1. fetch current PRIVATE `vendor/method-pin.json`;
+2. for every existing vendored path, compare stored blob SHA with candidate PUBLIC `main`;
+3. require all unchanged files to match;
+4. if any file drifted, stop and decide whether an explicit migration is required;
+5. vendor newly required method/schema files;
+6. update `method_commit`;
+7. update vendored blob SHAs;
+8. run PRIVATE validator;
+9. require stored assessments to exactly match deterministic recomputation;
+10. merge only after final-head CI PASS.
+
+No silent mixed-version state.
+
+---
+
+## 7. Verification ladder
+
+Canonical ladder:
+
+### stated
+User report, document assertion, or observed ownership only.
+
+### measured
+A relevant defensible quantity or continuity measurement exists.
+
+### field_tested
+The capability works under the relevant degraded/outage condition.
+
+### audited
+Field-tested plus evidence completeness, maintenance, independent review and critical dependency/SPOF treatment.
+
+Never promote a state merely because equipment exists.
+
+---
+
+## 8. Fail-closed state
+
+Unknown is a valid engineering result.
+
+The system must prefer:
+
+`unknown`
+
+over:
+
+`probably yes`.
+
+This applies particularly to:
+- autonomy
+- water potability
+- sustainable well yield
+- PV islanding
+- black-start
+- battery usable energy
+- communications path independence
+- offline-compute continuity
+- food autonomy
+- agricultural conversion
+- mobility degraded-mode range
+- Base Autonomy
+- First Failure Point
+- Personal R-Level
+
+### Preparedness invariant
+
+`Base Autonomy Days = min(critical capability autonomy_days)`
+
+is allowed only after required critical data is sufficiently known.
+
+Otherwise the system remains:
+- INCOMPLETE
+- UNKNOWN
+- DEGRADED
+
+as appropriate.
+
+---
+
+## 9. Model First → Batch Field Validation
+
+### Why
+
+If every capability model immediately stops for a site visit, the project becomes a sequence of disconnected checklists.
+
+Instead, first build a coherent dependency model.
+
+### Default workflow
+
+For each domain in the current modelling wave:
+
+1. build/verify PUBLIC method;
+2. create conservative PRIVATE baseline;
+3. identify dependencies;
+4. identify possible SPOFs;
+5. identify what evidence is missing;
+6. write a measurement/degraded-test plan;
+7. keep unknown values unknown;
+8. proceed to the next domain.
+
+After the whole wave is modelled:
+
+9. generate a consolidated field-audit work order;
+10. group tests by location, equipment, qualified-person requirement and cross-domain dependency;
+11. perform one coordinated field-verification session where practical;
+12. attach evidence to PRIVATE state;
+13. recompute all affected domains;
+14. recompute Preparedness;
+15. derive First Failure Point only if allowed.
+
+### Field Wave U1 — Core Utilities / Nervous System
+
+Domains:
+1. Water
+2. Energy
+3. Communications / Network / Offline Compute
+
+Cross-domain checks:
+- water extraction power path;
+- treatment power path;
+- communications resilient power path;
+- local compute resilient power path;
+- internet-loss local control;
+- Physical AI local/degraded operation;
+- offline data/knowledge access.
+
+**Do not start repeated site interruptions before U1 modelling is complete.**
+
+At U1 model completion, create one private consolidated:
+`FIELD-AUDIT-WAVE-U1.md`
+
+### Next modelling wave
+
+Default next critical sequence after U1:
+1. Food
+2. Mobility
+3. Sanitation / Medical
+4. Tools / Spares / Repair
+5. Offline Knowledge
+6. Industrial Space / Land Conversion
+7. Physical AI integration
+8. People / Trusted Network
+
+Financial resilience domains remain required but are not confused with the physical field-verification wave:
+- cash flow
+- liquidity
+- asset disposition
+
+---
+
+## 10. Cross-domain dependency engine
+
+Capabilities must not be evaluated as isolated possessions.
+
+Examples:
+
+### Water
+depends on:
+- source
+- pump
+- power
+- storage
+- treatment
+- quality
+- spares
+
+### Energy
+supports:
+- water extraction
+- communications
+- local compute
+- refrigeration
+- Physical AI
+- lighting/security
+
+### Communications
+depends on:
+- power
+- internal network
+- upstream external paths
+- local compute
+- auth/DNS/time/data dependencies
+
+### Physical AI
+depends on:
+- energy
+- communications
+- local compute
+- maps/models/data
+- maintenance/spares
+- safe degraded behavior
+
+The engine should prefer a dependency graph over a collection of domain scores.
+
+---
+
+## 11. Single Point of Failure discipline
+
+Potential SPOFs should be identified during modelling.
+
+Real SPOF confirmation should happen after evidence.
+
+Examples:
+- one well pump;
+- one inverter;
+- one router;
+- one server;
+- one road;
+- one person with unique knowledge;
+- one provider/upstream;
+- one fuel source.
+
+A duplicate of the same dependency is not necessarily redundancy.
+
+Diversity matters.
+
+---
+
+## 12. Radar-to-Preparedness handoff
+
+The Radar and Preparedness engines are coupled but not the same state.
+
+Radar:
+- detects material world change;
+- updates risk variables/edges/chain/scenario/lead time.
+
+Preparedness:
+- maps exposure;
+- identifies readiness gaps;
+- determines what action becomes justified.
+
+No automatic mapping is allowed from:
+- P0-P3
+to Stage I-IV,
+to R0-R5,
+to G0-G4.
+
+Every state transition needs its own explicit rule.
+
+The user-facing news conversation remains the presentation layer for the Radar.
+
+---
+
+## 13. Branch / PR / CI discipline
+
+### Branch
+Never build substantial work directly on `main`.
+
+### PR
+A PR should state:
+- exact base;
+- scope;
+- invariants;
+- evidence boundary;
+- non-goals;
+- acceptance criteria.
+
+### CI
+Always validate the current final head.
+
+An earlier green workflow is not proof for a later head.
+
+### CI failure
+Classify first:
+- algorithm bug;
+- schema bug;
+- stale fixture;
+- state inconsistency;
+- pin drift;
+- test bug.
+
+Do not weaken evidence/safety logic just to make CI green.
+
+### Merge
+Use expected head SHA when available.
+
+After merge, fresh-read `main` again.
+
+---
+
+## 14. Security engine
+
+### PUBLIC never stores
+- real balances / liabilities
+- exact private asset capacities
+- identifiable property/site details beyond explicitly public-safe abstraction
+- real network topology/provider mapping
+- credentials/keys/tokens
+- personal contacts
+- private routes
+- sensitive security deployment
+
+### PRIVATE may store
+- real operational state
+- evidence
+- topology
+- capacities
+- field results
+
+but still never stores:
+- passwords
+- tokens
+- private keys
+- recovery codes
+
+### Physical AI
+Defensive/non-weaponized only:
+- sensing
+- patrol/inspection
+- fire/smoke detection
+- infrastructure inspection
+- disaster reconnaissance
+- local safe fallback
+
+---
+
+## 15. Decision-quality engine
+
+The project must resist three forms of self-deception.
+
+### Doom bias
+Always preserve:
+- counterevidence;
+- stabilizers;
+- alternative explanations;
+- hypothesis falsification;
+- de-escalation.
+
+### Ownership bias
+Do not treat assets as resilience until tested.
+
+### Completion bias
+A document/Issue/schema is not completion.
+
+Completion means the relevant exit gate is satisfied and current `main` says so.
+
+---
+
+## 16. Handoff protocol
+
+Every significant session should leave GitHub in a state where a new agent can continue without conversation archaeology.
+
+### Required handoff fields
+
+- PUBLIC repository + exact main SHA
+- PRIVATE repository + exact main SHA
+- Project Engine version
+- current phase
+- current domain
+- last merged PR
+- open PRs
+- open Issues
+- current CI state
+- current PRIVATE method pin
+- field evidence deferred
+- next exact action
+- explicit safety/security boundary
+
+### Rule
+
+If a future ChatGPT/Codex cannot answer “what do I do next?” after reading the two repositories, the workflow is incomplete.
+
+---
+
+## 17. Current execution doctrine
+
+At Project Engine v0.1:
+
+- Phase 3R Radar Precision Upgrade is engineering-complete.
+- Phase 3C Capability Verification is active.
+- Water public/private baseline exists; field evidence deferred.
+- Energy public/private baseline exists; field evidence deferred.
+- Communications public method exists; private baseline is the current transaction.
+- Field Wave U1 should be executed only after Water + Energy + Communications modelling/baselines/plans are complete.
+
+After U1 modelling:
+1. produce one consolidated field-audit work order;
+2. review it with the user;
+3. collect site evidence;
+4. update PRIVATE state;
+5. recompute cross-domain dependencies and Preparedness;
+6. continue to Food and the next physical-capability wave.
+
+---
+
+## 18. Core project maxims
+
+> 没有改变判断的新闻，不应该打扰你。
+
+> 拥有 ≠ 可用；可用 ≠ 可持续；可持续 ≠ 自给。
+
+> 和平时期追求效率，危机时期追求冗余。
+
+> Internet Down ≠ System Down.
+
+> 云端可增强，本地可独立降级运行。
+
+> 准备越便宜、越通用、越可逆，越早做；准备越昂贵、越极端、越不可逆，触发门槛越高。
+
+> 长期准备看后果，不等概率；短期行动看概率，也看速度。
+
+The final system goal is not maximal stockpiling.
+
+It is:
+
+# Preserve Agency

--- a/docs/PROJECT-STATE.md
+++ b/docs/PROJECT-STATE.md
@@ -183,3 +183,29 @@ These results validate the encoded engineering contracts only. They do not estab
 Real dated-event calibration, false-positive/false-negative estimation on historical evidence, and threshold tuning remain Phase 5 work.
 
 The existing user-facing news-push conversation remains the presentation layer; Phase 3R upgraded the backend precision/state/memory contracts without replacing that presentation workflow.
+
+
+## Project Engine
+
+Canonical cross-repository workflow: **Project Engine v0.1**.
+
+Durable entry points:
+- `AGENTS.md`
+- `docs/PROJECT-ENGINE.md`
+- `config/project-engine.json`
+
+The engine defines:
+- PUBLIC method vs PRIVATE operational-state authority;
+- mandatory Fresh Read for every ChatGPT/Codex handoff;
+- method-pin / vendoring transaction discipline;
+- deterministic private assessment recomputation;
+- fail-closed unknown handling;
+- branch / PR / final-head CI merge discipline;
+- security boundary;
+- Model First → Batch Field Validation.
+
+Current field doctrine:
+
+`Water + Energy + Communications modelling → consolidated Field Wave U1 → coordinated site verification`
+
+Do not interrupt the modelling wave with repeated one-off field checks unless a safety-critical blocker makes modelling impossible.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,14 @@
 # Roadmap — Pre-V1.0
 
+## Project Engine v0.1 — CURRENT IMPLEMENTATION
+- [~] Canonical dual-repo workflow
+- [~] Mandatory AGENTS.md startup contract
+- [~] Machine-readable engine config
+- [~] Model First → Batch Field Validation doctrine
+- [~] ChatGPT/Codex handoff contract
+- [~] Public/private method-pin transaction rules
+
+
 ## Phase 0 — Architecture Baseline — COMPLETE
 - [x] 总体架构
 - [x] 四元多边模型

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,12 +1,12 @@
 # Roadmap — Pre-V1.0
 
-## Project Engine v0.1 — CURRENT IMPLEMENTATION
-- [~] Canonical dual-repo workflow
-- [~] Mandatory AGENTS.md startup contract
-- [~] Machine-readable engine config
-- [~] Model First → Batch Field Validation doctrine
-- [~] ChatGPT/Codex handoff contract
-- [~] Public/private method-pin transaction rules
+## Project Engine v0.1 — COMPLETE
+- [x] Canonical dual-repo workflow
+- [x] Mandatory AGENTS.md startup contract
+- [x] Machine-readable engine config
+- [x] Model First → Batch Field Validation doctrine
+- [x] ChatGPT/Codex handoff contract
+- [x] Public/private method-pin transaction rules
 
 
 ## Phase 0 — Architecture Baseline — COMPLETE


### PR DESCRIPTION
Closes #41

## Implements

- canonical dual-repository Project Engine v0.1
- mandatory root AGENTS.md startup protocol
- machine-readable project-engine.json
- PUBLIC vs PRIVATE authority matrix
- method-pin / vendoring transaction rules
- deterministic private recomputation invariant
- fail-closed unknown discipline
- final-head PR/CI discipline
- ChatGPT/Codex handoff contract
- Model First → Batch Field Validation
- Field Wave U1: Water + Energy + Communications

## Key doctrine

Do not interrupt every capability domain with one-off field checks.

First:
method → private conservative baseline → dependency/SPOF inference → measurement plan.

Then:
consolidated field work order → coordinated site verification → private evidence update → deterministic recompute.

## Security

Public repo remains method-only. Private operational values remain outside this repository.
