### PR TITLE
Phase 3C-04: Food Resilience Verification v0.1

### DIFF
--- a/docs/FOOD-RESILIENCE-VERIFICATION.md
+++ b/docs/FOOD-RESILIENCE-VERIFICATION.md
@@ -1,0 +1,143 @@
+# Food Resilience Verification v0.1
+
+## Core principle
+
+Food resilience is not a pile of groceries.
+
+It is six separate questions:
+
+1. **Buffer** — how many measured usable food-days exist now?
+2. **Nutrition** — is the stored plan nutritionally complete enough to be defensible?
+3. **Storage** — what survives without refrigeration and how is spoilage controlled?
+4. **Cooking** — can stored food still be prepared during a utility outage?
+5. **Replenishment** — can food be replaced through independent supply paths?
+6. **Production support** — can local production contribute measured output?
+
+The model deliberately prevents these concepts from collapsing into one claim.
+
+## 1. Inventory buffer
+
+Measured buffer days are:
+
+`usable food calories / measured daily calorie demand`
+
+Shelf-stable buffer days are calculated separately.
+
+No daily demand baseline → no food-days claim.
+
+The method does not prescribe the user's dietary intake. Private demand values must be established from the actual household/base plan.
+
+## 2. Nutrition gate
+
+Calories alone are not enough.
+
+The v0.1 nutrition gate requires a reviewed plan that maps:
+- protein sources;
+- fat sources;
+- micronutrient strategy;
+- dietary constraints;
+- special requirements.
+
+This is an audit completeness gate, not medical nutrition advice.
+
+## 3. Storage gate
+
+Storage resilience considers:
+- dry storage;
+- pest/moisture control;
+- cold-chain dependence.
+
+If food is critically dependent on refrigeration, cold-chain outage continuity must be demonstrated.
+
+Shelf-stable calories are therefore a particularly useful buffer metric.
+
+## 4. Cooking gate
+
+Food that cannot be safely prepared during an outage may not be a usable buffer.
+
+The gate separates:
+- normal cooking path;
+- backup path;
+- outage cooking test.
+
+The method does not prescribe a specific fuel technology.
+
+## 5. Replenishment diversity
+
+Two shops do not necessarily mean two supply chains.
+
+A replenishment path counts only when:
+- it is verified available; and
+- its independence group is known.
+
+Two verified paths sharing one independence group count as one.
+
+For `sustained_resilience`, the replenishment gate requires:
+- at least two independent verified supply paths; or
+- measured local production support.
+
+## 6. Local production / conversion
+
+Local production is tracked separately from inventory.
+
+A production-support candidate requires:
+- measured/field-tested output;
+- positive daily calorie equivalent;
+- production inputs mapped.
+
+Land ownership, soil availability or a planting idea do not satisfy this gate.
+
+Most importantly:
+
+> local production does not increase current inventory buffer days.
+
+This prevents an unverified garden from turning into imaginary infinite autonomy.
+
+## 7. Verification ladder
+
+### stated
+Food presence/gap may be known, but measured inventory + daily demand are incomplete.
+
+### measured
+Measured inventory and daily demand establish a defensible buffer.
+
+### field_tested
+For `emergency_buffer`:
+- inventory
+- nutrition
+- storage
+- outage cooking
+
+must pass.
+
+For `sustained_resilience`, replenishment must also pass.
+
+### audited
+Field-tested plus:
+- independent review;
+- rotation tested;
+- maintenance current;
+- evidence present;
+- no unresolved SPOF;
+- critical dependencies backed/not-required.
+
+## 8. Preparation architecture
+
+A practical preparation sequence is:
+
+### Layer 1 — shelf-stable buffer
+Build a rotating stock that does not require the cold chain.
+
+### Layer 2 — nutrition completeness
+Ensure the buffer is not merely starch.
+
+### Layer 3 — storage / cooking continuity
+Protect inventory and make sure it remains usable during utility loss.
+
+### Layer 4 — replenishment diversity
+Avoid one supplier/logistics dependency.
+
+### Layer 5 — production conversion
+Only after the buffer is sound, audit land/soil/water/inputs/time/skills for supplementary production.
+
+This is intentionally less cinematic than "become self-sufficient". It is also much more likely to work.

--- a/docs/PROJECT-STATE.md
+++ b/docs/PROJECT-STATE.md
@@ -113,7 +113,8 @@ Current aggregate checkpoint:
 - private Communications baseline: **COMPLETE / stated**;
 - Field Wave U1 model-first stage: **COMPLETE**;
 - U1 field work order: **READY BUT DEFERRED**;
-- current engineering node: **Food Resilience Verification v0.1 / public method implementation**;
+- Food Resilience Verification v0.1 public method: **COMPLETE**;
+- current engineering node: **private Food baseline instantiation**;
 - next after Food: **Mobility → Sanitation → Medical**.
 
 The public repository remains method-only. Real operational values stay in the separate private state layer.

--- a/docs/PROJECT-STATE.md
+++ b/docs/PROJECT-STATE.md
@@ -113,7 +113,7 @@ Current aggregate checkpoint:
 - private Communications baseline: **COMPLETE / stated**;
 - Field Wave U1 model-first stage: **COMPLETE**;
 - U1 field work order: **READY BUT DEFERRED**;
-- current engineering node: **Food Resilience Verification / Survival Core 4 completion**;
+- current engineering node: **Food Resilience Verification v0.1 / public method implementation**;
 - next after Food: **Mobility → Sanitation → Medical**.
 
 The public repository remains method-only. Real operational values stay in the separate private state layer.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -131,7 +131,7 @@ Private audit domains:
 - [~] 光伏 / 储能 / 离网能力 — public verification method + private baseline complete; field evidence pending
 - [ ] Physical AI / 防御性感知与巡检
 - [~] 网络 / 通信 / 离线计算 — PUBLIC + PRIVATE BASELINE COMPLETE; FIELD EVIDENCE DEFERRED
-- [~] 食品 / 农业转换 — CURRENT SURVIVAL CORE DOMAIN
+- [~] 食品 / 农业转换 — PUBLIC METHOD IMPLEMENTATION CURRENT
 - [ ] 车辆 / 机动 — CONTINUITY NEXT
 - [ ] 卫生 / 排污 / 废弃物 — CONTINUITY
 - [ ] 医疗 / 急救 — CONTINUITY

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -131,7 +131,7 @@ Private audit domains:
 - [~] 光伏 / 储能 / 离网能力 — public verification method + private baseline complete; field evidence pending
 - [ ] Physical AI / 防御性感知与巡检
 - [~] 网络 / 通信 / 离线计算 — PUBLIC + PRIVATE BASELINE COMPLETE; FIELD EVIDENCE DEFERRED
-- [~] 食品 / 农业转换 — PUBLIC METHOD IMPLEMENTATION CURRENT
+- [~] 食品 / 农业转换 — PUBLIC METHOD COMPLETE; PRIVATE BASELINE NEXT
 - [ ] 车辆 / 机动 — CONTINUITY NEXT
 - [ ] 卫生 / 排污 / 废弃物 — CONTINUITY
 - [ ] 医疗 / 急救 — CONTINUITY

--- a/examples/synthetic/food-resilience-audit.json
+++ b/examples/synthetic/food-resilience-audit.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "0.1.0",
+  "food_audit_id": "fra-synthetic-full",
+  "capability_id": "cap-food-synthetic",
+  "service_scope": "sustained_resilience",
+  "demand": {
+    "people_count": 4,
+    "daily_calorie_demand_kcal": 8000,
+    "special_requirements_mapped": true
+  },
+  "inventory": {
+    "inventory_count_status": "measured",
+    "usable_calories_kcal": 240000,
+    "shelf_stable_calories_kcal": 160000,
+    "rotation_status": "routine"
+  },
+  "nutrition": {
+    "plan_status": "reviewed",
+    "protein_sources_mapped": true,
+    "fat_sources_mapped": true,
+    "micronutrient_strategy_mapped": true,
+    "dietary_constraints_mapped": true
+  },
+  "storage": {
+    "dry_storage_status": "inspected_pass",
+    "pest_moisture_control_status": "adequate",
+    "cold_chain_dependency": "partial",
+    "cold_chain_outage_test": "not_run"
+  },
+  "cooking": {
+    "primary_path": "mixed",
+    "backup_path_status": "tested_pass",
+    "outage_cooking_test": "pass"
+  },
+  "replenishment": {
+    "supply_paths": [
+      {
+        "path_id": "foodpath-synthetic-a",
+        "independence_group_id": "group-a",
+        "status": "verified_available",
+        "critical": true
+      },
+      {
+        "path_id": "foodpath-synthetic-b",
+        "independence_group_id": "group-b",
+        "status": "verified_available",
+        "critical": true
+      }
+    ],
+    "local_production_status": "possible_unverified",
+    "production_daily_calorie_equivalent": null,
+    "production_inputs_mapped": null
+  },
+  "dependencies": [
+    {
+      "dependency_id": "synthetic-water",
+      "kind": "water",
+      "critical": true,
+      "backup_status": "ready"
+    }
+  ],
+  "single_points_of_failure": [],
+  "maintenance_status": "unknown",
+  "independent_review_completed": false,
+  "evidence_refs": [
+    "evidence/synthetic-food.md"
+  ],
+  "updated_at": "2026-09-01T00:00:00Z",
+  "data_sensitivity": "public"
+}

--- a/examples/synthetic/food-verification-assessment.json
+++ b/examples/synthetic/food-verification-assessment.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "0.1.0",
+  "assessment_id": "fva-synthetic-full",
+  "food_audit_id": "fra-synthetic-full",
+  "recommended_verification_status": "field_tested",
+  "inventory_gate_passed": true,
+  "nutrition_gate_passed": true,
+  "storage_gate_passed": true,
+  "cooking_gate_passed": true,
+  "replenishment_gate_passed": true,
+  "buffer_autonomy_days": 30,
+  "shelf_stable_buffer_days": 20,
+  "independent_replenishment_path_count": 2,
+  "production_support_candidate": false,
+  "blockers": [],
+  "as_of": "2026-09-01T00:00:00Z",
+  "sensitivity": "public"
+}

--- a/schemas/food-resilience-audit.schema.json
+++ b/schemas/food-resilience-audit.schema.json
@@ -1,0 +1,407 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/food-resilience-audit.schema.json",
+  "title": "Food Resilience Audit",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "food_audit_id",
+    "capability_id",
+    "service_scope",
+    "demand",
+    "inventory",
+    "nutrition",
+    "storage",
+    "cooking",
+    "replenishment",
+    "dependencies",
+    "single_points_of_failure",
+    "maintenance_status",
+    "independent_review_completed",
+    "evidence_refs",
+    "updated_at",
+    "data_sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "food_audit_id": {
+      "type": "string",
+      "pattern": "^fra-[A-Za-z0-9._-]+$"
+    },
+    "capability_id": {
+      "type": "string",
+      "pattern": "^cap-[A-Za-z0-9._-]+$"
+    },
+    "service_scope": {
+      "enum": [
+        "unknown",
+        "emergency_buffer",
+        "sustained_resilience"
+      ]
+    },
+    "demand": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "people_count",
+        "daily_calorie_demand_kcal",
+        "special_requirements_mapped"
+      ],
+      "properties": {
+        "people_count": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "daily_calorie_demand_kcal": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "exclusiveMinimum": 0
+        },
+        "special_requirements_mapped": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "inventory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "inventory_count_status",
+        "usable_calories_kcal",
+        "shelf_stable_calories_kcal",
+        "rotation_status"
+      ],
+      "properties": {
+        "inventory_count_status": {
+          "enum": [
+            "unknown",
+            "estimated",
+            "measured"
+          ]
+        },
+        "usable_calories_kcal": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "shelf_stable_calories_kcal": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "rotation_status": {
+          "enum": [
+            "unknown",
+            "not_established",
+            "routine",
+            "tested"
+          ]
+        }
+      }
+    },
+    "nutrition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "plan_status",
+        "protein_sources_mapped",
+        "fat_sources_mapped",
+        "micronutrient_strategy_mapped",
+        "dietary_constraints_mapped"
+      ],
+      "properties": {
+        "plan_status": {
+          "enum": [
+            "unknown",
+            "incomplete",
+            "reviewed"
+          ]
+        },
+        "protein_sources_mapped": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "fat_sources_mapped": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "micronutrient_strategy_mapped": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dietary_constraints_mapped": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "storage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "dry_storage_status",
+        "pest_moisture_control_status",
+        "cold_chain_dependency",
+        "cold_chain_outage_test"
+      ],
+      "properties": {
+        "dry_storage_status": {
+          "enum": [
+            "unknown",
+            "absent",
+            "present_unverified",
+            "inspected_pass",
+            "inspected_fail",
+            "not_required"
+          ]
+        },
+        "pest_moisture_control_status": {
+          "enum": [
+            "unknown",
+            "unverified",
+            "adequate",
+            "failed",
+            "not_required"
+          ]
+        },
+        "cold_chain_dependency": {
+          "enum": [
+            "unknown",
+            "none",
+            "partial",
+            "critical"
+          ]
+        },
+        "cold_chain_outage_test": {
+          "enum": [
+            "not_run",
+            "pass",
+            "partial",
+            "fail",
+            "not_required"
+          ]
+        }
+      }
+    },
+    "cooking": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "primary_path",
+        "backup_path_status",
+        "outage_cooking_test"
+      ],
+      "properties": {
+        "primary_path": {
+          "enum": [
+            "unknown",
+            "electric",
+            "gas",
+            "solid_fuel",
+            "no_cook",
+            "mixed",
+            "other"
+          ]
+        },
+        "backup_path_status": {
+          "enum": [
+            "unknown",
+            "none",
+            "present_unverified",
+            "tested_pass",
+            "tested_fail",
+            "not_required"
+          ]
+        },
+        "outage_cooking_test": {
+          "enum": [
+            "not_run",
+            "pass",
+            "partial",
+            "fail",
+            "not_required"
+          ]
+        }
+      }
+    },
+    "replenishment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "supply_paths",
+        "local_production_status",
+        "production_daily_calorie_equivalent",
+        "production_inputs_mapped"
+      ],
+      "properties": {
+        "supply_paths": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "path_id",
+              "independence_group_id",
+              "status",
+              "critical"
+            ],
+            "properties": {
+              "path_id": {
+                "type": "string",
+                "pattern": "^foodpath-[A-Za-z0-9._-]+$"
+              },
+              "independence_group_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "minLength": 1
+              },
+              "status": {
+                "enum": [
+                  "unknown",
+                  "identified_unverified",
+                  "verified_available",
+                  "unavailable"
+                ]
+              },
+              "critical": {
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        "local_production_status": {
+          "enum": [
+            "unknown",
+            "none",
+            "possible_unverified",
+            "measured_output",
+            "field_tested"
+          ]
+        },
+        "production_daily_calorie_equivalent": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "production_inputs_mapped": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "dependency_id",
+          "kind",
+          "critical",
+          "backup_status"
+        ],
+        "properties": {
+          "dependency_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "kind": {
+            "enum": [
+              "water",
+              "power",
+              "cooking_fuel",
+              "cold_chain",
+              "logistics",
+              "supplier",
+              "land",
+              "labor",
+              "seed_input",
+              "storage",
+              "other"
+            ]
+          },
+          "critical": {
+            "type": "boolean"
+          },
+          "backup_status": {
+            "enum": [
+              "none",
+              "partial",
+              "ready",
+              "unknown",
+              "not_required"
+            ]
+          }
+        }
+      }
+    },
+    "single_points_of_failure": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "maintenance_status": {
+      "enum": [
+        "current",
+        "due",
+        "overdue",
+        "unknown"
+      ]
+    },
+    "independent_review_completed": {
+      "type": "boolean"
+    },
+    "evidence_refs": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "data_sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/schemas/food-verification-assessment.schema.json
+++ b/schemas/food-verification-assessment.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/food-verification-assessment.schema.json",
+  "title": "Food Verification Assessment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "assessment_id",
+    "food_audit_id",
+    "recommended_verification_status",
+    "inventory_gate_passed",
+    "nutrition_gate_passed",
+    "storage_gate_passed",
+    "cooking_gate_passed",
+    "replenishment_gate_passed",
+    "buffer_autonomy_days",
+    "shelf_stable_buffer_days",
+    "independent_replenishment_path_count",
+    "production_support_candidate",
+    "blockers",
+    "as_of",
+    "sensitivity"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "assessment_id": {
+      "type": "string",
+      "pattern": "^fva-[A-Za-z0-9._-]+$"
+    },
+    "food_audit_id": {
+      "type": "string",
+      "pattern": "^fra-[A-Za-z0-9._-]+$"
+    },
+    "recommended_verification_status": {
+      "enum": [
+        "stated",
+        "measured",
+        "field_tested",
+        "audited"
+      ]
+    },
+    "inventory_gate_passed": {
+      "type": "boolean"
+    },
+    "nutrition_gate_passed": {
+      "type": "boolean"
+    },
+    "storage_gate_passed": {
+      "type": "boolean"
+    },
+    "cooking_gate_passed": {
+      "type": "boolean"
+    },
+    "replenishment_gate_passed": {
+      "type": "boolean"
+    },
+    "buffer_autonomy_days": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "shelf_stable_buffer_days": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "independent_replenishment_path_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "production_support_candidate": {
+      "type": "boolean"
+    },
+    "blockers": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "as_of": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sensitivity": {
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/scripts/validate_schemas.py
+++ b/scripts/validate_schemas.py
@@ -52,6 +52,8 @@ PAIRS = {
     "replay_suite_summary": ("schemas/replay-suite-summary.schema.json", "examples/synthetic/replay-suite-summary.json"),
     "communications_resilience_audit": ("schemas/communications-resilience-audit.schema.json", "examples/synthetic/communications-resilience-audit.json"),
     "communications_verification_assessment": ("schemas/communications-verification-assessment.schema.json", "examples/synthetic/communications-verification-assessment.json"),
+    "food_resilience_audit": ("schemas/food-resilience-audit.schema.json", "examples/synthetic/food-resilience-audit.json"),
+    "food_verification_assessment": ("schemas/food-verification-assessment.schema.json", "examples/synthetic/food-verification-assessment.json"),
 }
 
 def load(path):
@@ -361,6 +363,40 @@ def semantic_errors(name, obj):
             and obj["power_gate_passed"]
         ):
             errors.append("degraded local candidate requires internal + offline compute + power gates")
+    elif name == "food_resilience_audit":
+        inv = obj["inventory"]
+        demand = obj["demand"]
+        if (
+            inv["shelf_stable_calories_kcal"] is not None
+            and inv["usable_calories_kcal"] is not None
+            and inv["shelf_stable_calories_kcal"] > inv["usable_calories_kcal"]
+        ):
+            errors.append("shelf-stable calories cannot exceed total usable calories")
+        if inv["inventory_count_status"] == "measured" and inv["usable_calories_kcal"] is None:
+            errors.append("measured food inventory requires usable_calories_kcal")
+        if demand["daily_calorie_demand_kcal"] is not None and demand["people_count"] is None:
+            errors.append("daily calorie demand requires people_count context")
+        path_ids = [path["path_id"] for path in obj["replenishment"]["supply_paths"]]
+        if len(path_ids) != len(set(path_ids)):
+            errors.append("food replenishment path_id values must be unique")
+        for path in obj["replenishment"]["supply_paths"]:
+            if path["status"] == "verified_available" and not path["independence_group_id"]:
+                errors.append(f"{path['path_id']}: verified food path requires independence_group_id")
+        repl = obj["replenishment"]
+        if repl["local_production_status"] in {"measured_output", "field_tested"}:
+            if repl["production_daily_calorie_equivalent"] is None or repl["production_daily_calorie_equivalent"] <= 0:
+                errors.append("measured/field-tested food production requires positive calorie-equivalent output")
+            if repl["production_inputs_mapped"] is not True:
+                errors.append("measured/field-tested food production requires mapped inputs")
+    elif name == "food_verification_assessment":
+        if (
+            obj["buffer_autonomy_days"] is not None
+            and obj["shelf_stable_buffer_days"] is not None
+            and obj["shelf_stable_buffer_days"] > obj["buffer_autonomy_days"]
+        ):
+            errors.append("shelf-stable buffer days cannot exceed total buffer days")
+        if obj["production_support_candidate"] and obj["recommended_verification_status"] == "stated":
+            errors.append("production support candidate cannot coexist with stated-only verification")
     elif name == "structural_delta":
         h_order = {"H0": 0, "H1": 1, "H2": 2, "H3": 3}
         c_order = {"C0": 0, "C1": 1, "C2": 2, "C3": 3}

--- a/src/psrro/__init__.py
+++ b/src/psrro/__init__.py
@@ -1,3 +1,4 @@
+from .food import assess_food_verification
 from .communications import assess_communications_verification
 from .intelligence_replay import (
     evaluate_replay_step,
@@ -51,6 +52,7 @@ from .quantification import (
 )
 
 __all__ = [
+    "assess_food_verification",
     "assess_communications_verification",
     "evaluate_replay_step",
     "summarize_replay_suite",

--- a/src/psrro/food.py
+++ b/src/psrro/food.py
@@ -1,0 +1,182 @@
+"""Food resilience verification v0.1.
+
+Food resilience separates current buffer, nutrition planning, storage/cooking
+continuity, replenishment diversity, and local-production support.
+
+Local production is never treated as infinite food autonomy. Inventory days
+remain inventory days.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def _independent_replenishment_paths(audit: Mapping) -> int:
+    groups: set[str] = set()
+    for path in audit["replenishment"]["supply_paths"]:
+        if (
+            path["status"] == "verified_available"
+            and path["independence_group_id"]
+        ):
+            groups.add(str(path["independence_group_id"]))
+    return len(groups)
+
+
+def assess_food_verification(audit: Mapping) -> dict:
+    blockers: list[str] = []
+    scope = audit["service_scope"]
+    demand = audit["demand"]
+    inventory = audit["inventory"]
+    nutrition = audit["nutrition"]
+    storage = audit["storage"]
+    cooking = audit["cooking"]
+    replenishment = audit["replenishment"]
+
+    daily_kcal = demand["daily_calorie_demand_kcal"]
+    usable_kcal = inventory["usable_calories_kcal"]
+    shelf_kcal = inventory["shelf_stable_calories_kcal"]
+
+    inventory_gate = bool(
+        inventory["inventory_count_status"] == "measured"
+        and usable_kcal is not None
+        and daily_kcal is not None
+        and daily_kcal > 0
+    )
+
+    nutrition_gate = bool(
+        nutrition["plan_status"] == "reviewed"
+        and nutrition["protein_sources_mapped"] is True
+        and nutrition["fat_sources_mapped"] is True
+        and nutrition["micronutrient_strategy_mapped"] is True
+        and nutrition["dietary_constraints_mapped"] is True
+        and demand["special_requirements_mapped"] is True
+    )
+
+    cold_chain_gate = (
+        storage["cold_chain_dependency"] in {"none", "partial"}
+        or (
+            storage["cold_chain_dependency"] == "critical"
+            and storage["cold_chain_outage_test"] == "pass"
+        )
+    )
+
+    storage_gate = bool(
+        storage["dry_storage_status"] in {"inspected_pass", "not_required"}
+        and storage["pest_moisture_control_status"] in {"adequate", "not_required"}
+        and cold_chain_gate
+    )
+
+    cooking_gate = bool(
+        cooking["outage_cooking_test"] in {"pass", "not_required"}
+        and cooking["backup_path_status"] in {"tested_pass", "not_required"}
+    )
+
+    independent_paths = _independent_replenishment_paths(audit)
+
+    production_support = bool(
+        replenishment["local_production_status"] in {"measured_output", "field_tested"}
+        and replenishment["production_daily_calorie_equivalent"] is not None
+        and replenishment["production_daily_calorie_equivalent"] > 0
+        and replenishment["production_inputs_mapped"] is True
+    )
+
+    replenishment_gate = bool(independent_paths >= 2 or production_support)
+
+    buffer_days = None
+    shelf_days = None
+    if usable_kcal is not None and daily_kcal is not None and daily_kcal > 0:
+        buffer_days = usable_kcal / daily_kcal
+    if shelf_kcal is not None and daily_kcal is not None and daily_kcal > 0:
+        shelf_days = shelf_kcal / daily_kcal
+
+    asset_present = bool(
+        (usable_kcal is not None and usable_kcal > 0)
+        or inventory["inventory_count_status"] in {"estimated", "measured"}
+        or replenishment["supply_paths"]
+        or replenishment["local_production_status"] not in {"unknown", "none"}
+    )
+
+    measured_evidence = bool(inventory_gate)
+
+    if scope == "unknown":
+        blockers.append("food service scope not defined")
+
+    if not inventory_gate:
+        blockers.append("measured food inventory and daily demand baseline incomplete")
+
+    if not nutrition_gate:
+        blockers.append("nutrition coverage plan incomplete")
+
+    if not storage_gate:
+        blockers.append("food storage resilience not demonstrated")
+
+    if storage["cold_chain_dependency"] == "critical" and storage["cold_chain_outage_test"] != "pass":
+        blockers.append("critical cold-chain continuity not demonstrated")
+
+    if not cooking_gate:
+        blockers.append("outage cooking path not demonstrated")
+
+    if scope == "sustained_resilience" and not replenishment_gate:
+        blockers.append("independent replenishment or measured local production not demonstrated")
+
+    if shelf_kcal is not None and usable_kcal is not None and shelf_kcal > usable_kcal:
+        blockers.append("shelf-stable calories cannot exceed total usable calories")
+
+    if not asset_present:
+        blockers.append("no food resilience asset confirmed")
+        status = "stated"
+    elif not measured_evidence:
+        status = "stated"
+    else:
+        status = "measured"
+
+    if scope == "emergency_buffer":
+        field_gate = inventory_gate and nutrition_gate and storage_gate and cooking_gate
+    elif scope == "sustained_resilience":
+        field_gate = (
+            inventory_gate
+            and nutrition_gate
+            and storage_gate
+            and cooking_gate
+            and replenishment_gate
+        )
+    else:
+        field_gate = False
+
+    if status == "measured" and field_gate:
+        status = "field_tested"
+
+    if (
+        status == "field_tested"
+        and audit["independent_review_completed"]
+        and audit["maintenance_status"] == "current"
+        and inventory["rotation_status"] == "tested"
+        and audit["evidence_refs"]
+        and not audit["single_points_of_failure"]
+        and all(
+            dep["backup_status"] not in {"none", "unknown"}
+            for dep in audit["dependencies"]
+            if dep["critical"]
+        )
+    ):
+        status = "audited"
+
+    return {
+        "schema_version": "0.1.0",
+        "assessment_id": f"fva-{audit['food_audit_id'][4:]}",
+        "food_audit_id": audit["food_audit_id"],
+        "recommended_verification_status": status,
+        "inventory_gate_passed": inventory_gate,
+        "nutrition_gate_passed": nutrition_gate,
+        "storage_gate_passed": storage_gate,
+        "cooking_gate_passed": cooking_gate,
+        "replenishment_gate_passed": replenishment_gate,
+        "buffer_autonomy_days": None if buffer_days is None else round(buffer_days, 6),
+        "shelf_stable_buffer_days": None if shelf_days is None else round(shelf_days, 6),
+        "independent_replenishment_path_count": independent_paths,
+        "production_support_candidate": production_support,
+        "blockers": sorted(set(blockers)),
+        "as_of": audit["updated_at"],
+        "sensitivity": audit["data_sensitivity"],
+    }

--- a/tests/test_food.py
+++ b/tests/test_food.py
@@ -1,0 +1,211 @@
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from src.psrro.food import assess_food_verification
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def base_audit(scope="sustained_resilience"):
+    return {
+        "food_audit_id": "fra-synthetic",
+        "service_scope": scope,
+        "demand": {
+            "people_count": 4,
+            "daily_calorie_demand_kcal": 8000,
+            "special_requirements_mapped": True,
+        },
+        "inventory": {
+            "inventory_count_status": "measured",
+            "usable_calories_kcal": 240000,
+            "shelf_stable_calories_kcal": 160000,
+            "rotation_status": "routine",
+        },
+        "nutrition": {
+            "plan_status": "reviewed",
+            "protein_sources_mapped": True,
+            "fat_sources_mapped": True,
+            "micronutrient_strategy_mapped": True,
+            "dietary_constraints_mapped": True,
+        },
+        "storage": {
+            "dry_storage_status": "inspected_pass",
+            "pest_moisture_control_status": "adequate",
+            "cold_chain_dependency": "partial",
+            "cold_chain_outage_test": "not_run",
+        },
+        "cooking": {
+            "primary_path": "mixed",
+            "backup_path_status": "tested_pass",
+            "outage_cooking_test": "pass",
+        },
+        "replenishment": {
+            "supply_paths": [
+                {
+                    "path_id": "foodpath-a",
+                    "independence_group_id": "group-a",
+                    "status": "verified_available",
+                    "critical": True,
+                },
+                {
+                    "path_id": "foodpath-b",
+                    "independence_group_id": "group-b",
+                    "status": "verified_available",
+                    "critical": True,
+                },
+            ],
+            "local_production_status": "possible_unverified",
+            "production_daily_calorie_equivalent": None,
+            "production_inputs_mapped": None,
+        },
+        "dependencies": [],
+        "single_points_of_failure": [],
+        "maintenance_status": "unknown",
+        "independent_review_completed": False,
+        "evidence_refs": ["evidence/synthetic-food.md"],
+        "updated_at": "2026-09-01T00:00:00Z",
+        "data_sensitivity": "public",
+    }
+
+
+class ExampleContractTests(unittest.TestCase):
+    def test_synthetic_audit_recomputes_assessment_fixture(self):
+        audit = json.loads(
+            (ROOT / "examples" / "synthetic" / "food-resilience-audit.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        expected = json.loads(
+            (ROOT / "examples" / "synthetic" / "food-verification-assessment.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(assess_food_verification(audit), expected)
+
+
+class BufferTests(unittest.TestCase):
+    def test_measured_inventory_days(self):
+        result = assess_food_verification(base_audit())
+        self.assertEqual(result["buffer_autonomy_days"], 30.0)
+        self.assertEqual(result["shelf_stable_buffer_days"], 20.0)
+
+    def test_no_daily_demand_means_no_days(self):
+        audit = base_audit()
+        audit["demand"]["daily_calorie_demand_kcal"] = None
+        result = assess_food_verification(audit)
+        self.assertIsNone(result["buffer_autonomy_days"])
+        self.assertFalse(result["inventory_gate_passed"])
+
+    def test_shelf_stable_cannot_exceed_total_without_blocker(self):
+        audit = base_audit()
+        audit["inventory"]["shelf_stable_calories_kcal"] = 300000
+        result = assess_food_verification(audit)
+        self.assertIn("shelf-stable calories cannot exceed total usable calories", result["blockers"])
+
+
+class StorageCookingNutritionTests(unittest.TestCase):
+    def test_critical_cold_chain_requires_outage_test(self):
+        audit = base_audit()
+        audit["storage"]["cold_chain_dependency"] = "critical"
+        result = assess_food_verification(audit)
+        self.assertFalse(result["storage_gate_passed"])
+        self.assertIn("critical cold-chain continuity not demonstrated", result["blockers"])
+
+    def test_nutrition_requires_complete_reviewed_map(self):
+        audit = base_audit()
+        audit["nutrition"]["micronutrient_strategy_mapped"] = False
+        result = assess_food_verification(audit)
+        self.assertFalse(result["nutrition_gate_passed"])
+
+    def test_outage_cooking_requires_tested_backup(self):
+        audit = base_audit()
+        audit["cooking"]["backup_path_status"] = "present_unverified"
+        result = assess_food_verification(audit)
+        self.assertFalse(result["cooking_gate_passed"])
+
+
+class ReplenishmentTests(unittest.TestCase):
+    def test_two_independent_paths_pass(self):
+        result = assess_food_verification(base_audit())
+        self.assertTrue(result["replenishment_gate_passed"])
+        self.assertEqual(result["independent_replenishment_path_count"], 2)
+
+    def test_same_upstream_group_does_not_count_as_two(self):
+        audit = base_audit()
+        audit["replenishment"]["supply_paths"][1]["independence_group_id"] = "group-a"
+        result = assess_food_verification(audit)
+        self.assertFalse(result["replenishment_gate_passed"])
+        self.assertEqual(result["independent_replenishment_path_count"], 1)
+
+    def test_measured_local_production_can_support_replenishment(self):
+        audit = base_audit()
+        audit["replenishment"]["supply_paths"] = []
+        audit["replenishment"]["local_production_status"] = "measured_output"
+        audit["replenishment"]["production_daily_calorie_equivalent"] = 1500
+        audit["replenishment"]["production_inputs_mapped"] = True
+        result = assess_food_verification(audit)
+        self.assertTrue(result["production_support_candidate"])
+        self.assertTrue(result["replenishment_gate_passed"])
+        self.assertEqual(result["buffer_autonomy_days"], 30.0)
+
+    def test_unverified_agriculture_does_not_count(self):
+        audit = base_audit()
+        audit["replenishment"]["supply_paths"] = []
+        audit["replenishment"]["local_production_status"] = "possible_unverified"
+        audit["replenishment"]["production_daily_calorie_equivalent"] = None
+        result = assess_food_verification(audit)
+        self.assertFalse(result["production_support_candidate"])
+        self.assertFalse(result["replenishment_gate_passed"])
+
+
+class VerificationLadderTests(unittest.TestCase):
+    def test_emergency_buffer_does_not_require_replenishment(self):
+        audit = base_audit("emergency_buffer")
+        audit["replenishment"]["supply_paths"] = []
+        result = assess_food_verification(audit)
+        self.assertEqual(result["recommended_verification_status"], "field_tested")
+        self.assertFalse(result["replenishment_gate_passed"])
+
+    def test_sustained_scope_requires_replenishment(self):
+        audit = base_audit()
+        audit["replenishment"]["supply_paths"] = []
+        result = assess_food_verification(audit)
+        self.assertEqual(result["recommended_verification_status"], "measured")
+
+    def test_presence_without_measured_inventory_stays_stated(self):
+        audit = base_audit()
+        audit["inventory"]["inventory_count_status"] = "estimated"
+        audit["inventory"]["usable_calories_kcal"] = None
+        audit["inventory"]["shelf_stable_calories_kcal"] = None
+        result = assess_food_verification(audit)
+        self.assertEqual(result["recommended_verification_status"], "stated")
+
+    def test_audited_requires_review_rotation_dependencies_and_no_spof(self):
+        audit = base_audit()
+        audit["independent_review_completed"] = True
+        audit["maintenance_status"] = "current"
+        audit["inventory"]["rotation_status"] = "tested"
+        audit["dependencies"] = [
+            {
+                "dependency_id": "food-water",
+                "kind": "water",
+                "critical": True,
+                "backup_status": "ready",
+            }
+        ]
+        result = assess_food_verification(audit)
+        self.assertEqual(result["recommended_verification_status"], "audited")
+
+        bad = copy.deepcopy(audit)
+        bad["dependencies"][0]["backup_status"] = "unknown"
+        self.assertEqual(
+            assess_food_verification(bad)["recommended_verification_status"],
+            "field_tested",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #47

## Implements

- Food Resilience Audit schema
- Food Verification Assessment schema
- deterministic Food verification logic
- measured total buffer days
- shelf-stable buffer days
- nutrition/storage/cooking/replenishment gates
- replenishment independence groups
- local production support candidate
- public-safe synthetic fixtures
- unit tests + unified validator
- documentation

## Core invariants

- food presence != measured food days
- calories != complete nutrition
- shelf-stable buffer tracked separately
- critical cold chain requires outage continuity evidence
- two supply paths in one independence group count as one
- unverified agriculture does not count as replenishment
- measured local production never increases current inventory buffer days
- no self-sufficiency claim from land ownership

## Security

No real inventory, household demand or site production values are added to this PUBLIC repository.
